### PR TITLE
[hotfix/search-null] 검색 키워드가 null일 때 오류 해결

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
@@ -304,8 +304,11 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
                     call: Call<Documents>,
                     response: Response<Documents>
                 ) {
-                    currentDocuments = response.body()!!.documents
-                    addPOIItemsForDocuments(currentDocuments!!, mapView)
+                    val body = response.body()
+                    if(body != null){
+                        currentDocuments = body.documents
+                        addPOIItemsForDocuments(currentDocuments!!, mapView)
+                    }
                 }
 
                 override fun onFailure(call: Call<Documents>, t: Throwable) {


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [x] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
검색 키워드가 null일 때의 오류를 해결하였습니다. keyword가 공백일 때의 response의 body가, _길이가 0인 배열_이 아니라, _null_이 반환되어 생긴 문제였습니다. 즉, 검색된 항목이 없을 때는 길이가 0인 배열을 받고, 검색 키워드가 null일 경우 null값을 받는다는 것입니다.

## 변경사항
 - searchKeyword()에서, body가 null일 때의 예외처리를 하였습니다.
 
## 비고


## 품질 관리를 위한 체크리스트
 - [x] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
