### PR TITLE
[hotfix/fixed-map-info-textview-overlap] 위치 정보 TextView 겹치는 오류 해결

### DIFF
--- a/client/android/app/src/main/res/layout/fragment_map.xml
+++ b/client/android/app/src/main/res/layout/fragment_map.xml
@@ -76,26 +76,42 @@
             android:layout_width="match_parent"
             android:layout_height="40dp"
             app:layout_constraintTop_toTopOf="parent">
-            <TextView
-                android:id="@+id/location_place_name"
-                android:text="place_name"
-                android:layout_width="wrap_content"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/location_place_category_layout"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textSize="20dp"
-                android:textColor="@color/black"
+                app:layout_constrainedWidth="true"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                />
-            <TextView
-                android:id="@+id/location_category_name"
-                android:text="category_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="14dp"
-                android:layout_marginStart="8dp"
-                app:layout_constraintBottom_toBottomOf="@+id/location_place_name"
-                app:layout_constraintStart_toEndOf="@+id/location_place_name"
-                />
+                app:layout_constraintEnd_toStartOf="@id/location_distance"
+                app:layout_constraintHorizontal_chainStyle="spread_inside">
+                <TextView
+                    android:id="@+id/location_place_name"
+                    android:text="place_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="20dp"
+                    android:textColor="@color/black"
+                    android:singleLine="true"
+                    app:layout_constraintHorizontal_chainStyle="packed"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constrainedWidth="true"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/location_category_name"
+                    />
+                <TextView
+                    android:id="@+id/location_category_name"
+                    android:text="category_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="14dp"
+                    android:layout_marginStart="8dp"
+                    app:layout_constraintStart_toEndOf="@id/location_place_name"
+                    app:layout_constraintBottom_toBottomOf="@id/location_place_name"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+            </androidx.constraintlayout.widget.ConstraintLayout>
             <TextView
                 android:id="@+id/location_distance"
                 android:text="0m"
@@ -104,7 +120,8 @@
                 android:textSize="18dp"
                 android:textColor="@color/carrot"
                 android:layout_marginStart="8dp"
-                app:layout_constraintBottom_toBottomOf="@+id/location_place_name"
+                app:layout_constraintStart_toEndOf="@id/location_place_category_layout"
+                app:layout_constraintBottom_toBottomOf="@id/location_place_category_layout"
                 app:layout_constraintEnd_toEndOf="parent"
                 />
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [X] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
지도 탭에서 위치 정보가 긴 경우에 TextView가 겹치는 현상을 해결하였습니다.

## 변경사항
- 위치 이름 정보와 위치 분류 정보를 하나의 ConstraintLayout으로 묶음.
- singleLine, layout_constrainedWidth 속성을 이용하여 텍스트(위치 이름 정보)가 인접한 뷰와 겹쳐질 정도로 길어지면 뒷부분을 적당히 생략하여 "..."으로 표시하도록 함.

## 비고
### Before
<img src="https://user-images.githubusercontent.com/48195650/125165341-81fa2180-e1d1-11eb-9274-f7fefd50e086.png" width="40%"> <img src="https://user-images.githubusercontent.com/48195650/125165346-845c7b80-e1d1-11eb-918f-ed3acde5f98c.png" width="40%">

### After
<img src="https://user-images.githubusercontent.com/48195650/125165366-8de5e380-e1d1-11eb-9d99-771bf774d31f.png" width="40%"> <img src="https://user-images.githubusercontent.com/48195650/125165370-90483d80-e1d1-11eb-9ffe-ec05a416d4a9.png" width="40%">

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [X] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [X] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [X] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [X] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [X] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [X] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
