### PR TITLE
[hotfix/entity-naming-change] PetSchedule 엔티티의 컬럼명 변경

### DIFF
--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/application/PetScheduleService.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/application/PetScheduleService.java
@@ -41,7 +41,7 @@ public class PetScheduleService {
                 .petList(appliedPetList)
                 .time(LocalTime.parse(reqDto.getTime()))
                 .memo(reqDto.getMemo())
-                .enable(false)
+                .enabled(false)
                 .build();
 
         // save(id가 없는 transient 상태의 객체) -> EntityManger.persist() => save
@@ -114,8 +114,8 @@ public class PetScheduleService {
         if (reqDto.getMemo() != null && !reqDto.getMemo().equals(petSchedule.getMemo())) {
             petSchedule.setMemo(reqDto.getMemo());
         }
-        if (reqDto.getEnable() != null && !reqDto.getEnable().equals(petSchedule.getEnable())) {
-            petSchedule.setEnable(reqDto.getEnable());
+        if (reqDto.getEnabled() != null && !reqDto.getEnabled().equals(petSchedule.getEnabled())) {
+            petSchedule.setEnabled(reqDto.getEnabled());
         }
 
         // save(id가 있는 detached 상태의 객체) -> EntityManger.merge() => update

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/dao/PetSchedule.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/dao/PetSchedule.java
@@ -37,7 +37,7 @@ public class PetSchedule {
     @Column
     private LocalTime time;
     private String memo;
-    private Boolean enable;
+    private Boolean enabled;
 
     @Transient
     private String petIdList;

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/dto/UpdatePetScheduleReqDto.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/dto/UpdatePetScheduleReqDto.java
@@ -16,5 +16,5 @@ public class UpdatePetScheduleReqDto {
     private String time;
     @Size(max = 200, message = "valid.petSchedule.memo.size")
     private String memo;
-    private Boolean enable;
+    private Boolean enabled;
 }


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
- PetSchedule 엔티티의 컬럼의 이름을 변경하였습니다

## 변경사항
- PetSchedule 엔티티의 컬럼 enable을 enabled로 변경, 관련 로직, DTO들도 변경

 
## 비고
- 이 PR 이후 각자 컴퓨터의 Pet-Management DB를 Drop 하고 다시 Create 하는 것을 추천합니다. DB의 많은 부분들이 변경되었기 때문에 DB를 새로 Refresh 하지 않고 테스트시 문제가 발생할 수 있습니다
- Postman의 관련 테스트도 변경하였고, Auth의 token은 {{token}} 글로벌 변수로 설정되었습니다. 로그인 요청을 보낸 후 받은 token 값을 우클릭 하여 Set Global -> token으로 지정하면 다른 요청 시 일일히 Auth Token을 변경하지 않아도 됩니다
- 클라이언트 리펙토링: https://github.com/NewCentury99/Pet-Management/pull/58 과 https://github.com/NewCentury99/Pet-Management/pull/59 둘 모두 Merge 된 이후 PetSchedule의 enable를 enabled로 변경해주시고 관련 로직들의 이름도 변경해 주시면 됩니다


## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [ ] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [ ] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [ ] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [ ] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [ ] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [ ] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
