### PR TITLE
[hotfix/post-update-media-related-bug-fixes] Client 포스트 수정 시 미디어 파일 관련 버그 수정

### DIFF
--- a/client/android/.idea/misc.xml
+++ b/client/android/.idea/misc.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectPlainTextFileTypeManager">
-    <file url="file://$PROJECT_DIR$/app/src/main/res/layout/fragment_post_media_item.xml" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
+++ b/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
@@ -25,7 +25,7 @@ import java.util.*;
 @Service
 public class FileService {
     private final MessageSource msgSrc = MessageConfig.getStorageMessageSource();
-    private final String storageRootPath = "E:\\TempDev\\Pet-Management\\storage";
+    private final String storageRootPath = "D:\\TempDev\\Pet-Management\\storage";
 
     // 파일 메타데이터 목록(stringify 된 JSON)을 이용하여 파일 읽기
     public byte[] readFileFromFileMetadataListJson(String fileMetadataListJson, Integer fileIndex) throws IOException {


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [X] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
안드로이드 Client의 포스트 수정 시 미디어 파일 관련 버그를 수정하였습니다.

### 버그 설명
- 비동기로 미디어 파일을 하나씩 불러오는 과정에서 만약 크기가 큰 파일이 앞에 있고, 해당 파일이 다운로드 되기 전에 이후 파일들의 다운로드가 끝나게 되면, 이후 파일들이 RecyclerView에 먼저 추가가 되고, 크기가 큰 파일이 다운로드 되기 전에 로딩 화면이 숨겨지고 메인 화면이 표시되는 버그
- 파일 다운로드 중 뒤로가기를 클릭했을 때 오류가 뜨는 버그

## 변경사항
- 미디어 파일이 다운로드 될 때마다 리스트에 add 하는 방식이 아닌, 미디어 파일의 개수를 이용하여 관련 리스트의 크기를 미리 할당하고, 각 index에 맞게(순서에 맞게) 추가하는 방식
- 리스트에 비어있는 인덱스가 없을 때, 모든 다운로드가 완료됐다고 판단하고 로딩 화면을 숨기고 메인 화면을 표시
- 파일 다운로드 중 뒤로가기를 클릭했을 때 오류가 뜨던 버그 fix
 
## 비고
### DEMO(before)
https://user-images.githubusercontent.com/48195650/130315291-2ace6646-b41f-4d93-a65a-ddee3b9ac54e.mp4

### DEMO(after)
https://user-images.githubusercontent.com/48195650/130315295-278abba0-ea09-4a6a-819d-d832e17a1f2e.mp4

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [X] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [X] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [X] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [X] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [X] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [X] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
