### PR TITLE
[hotfix/file-copy-delete-unification] Client 임시파일 생성/삭제 과정 통일

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
@@ -149,8 +149,7 @@ class Util {
         }
 
         fun deleteCopiedFiles(context: Context, directory: String) {
-            val dir = File(context.getExternalFilesDir(null).toString() +
-                    File.separator + "pet_management" + File.separator + directory)
+            val dir = File(context.getExternalFilesDir(null).toString() + File.separator + directory)
             dir.deleteRecursively()
         }
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
@@ -22,6 +22,7 @@ import androidx.annotation.RequiresApi
 import com.sju18001.petmanagement.restapi.Place
 import okhttp3.ResponseBody
 import org.json.JSONObject
+import java.io.File
 import java.time.LocalDateTime
 import java.time.ZoneId
 
@@ -145,6 +146,12 @@ class Util {
             val windowMetrics = activity.windowManager.currentWindowMetrics
             val insets = windowMetrics.windowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())
             return windowMetrics.bounds.width() - insets.left - insets.right
+        }
+
+        fun deleteCopiedFiles(context: Context, directory: String) {
+            val dir = File(context.getExternalFilesDir(null).toString() +
+                    File.separator + "pet_management" + File.separator + directory)
+            dir.deleteRecursively()
         }
     }
 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerUtil.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerUtil.kt
@@ -9,11 +9,14 @@ import java.io.FileOutputStream
 
 class ServerUtil {
     companion object{
-        fun createCopyAndReturnRealPathLocal(context: Context, uri: Uri): String {
+        fun createCopyAndReturnRealPathLocal(context: Context, uri: Uri, directory: String): String {
             val mimeTypeMap = MimeTypeMap.getSingleton()
-            val extension = '.' + mimeTypeMap.getExtensionFromMimeType(context.contentResolver.getType(uri))!!
+            val extension = mimeTypeMap.getExtensionFromMimeType(context.contentResolver.getType(uri))!!
 
-            val newFilePath = context.applicationInfo.dataDir + File.separator + System.currentTimeMillis() + extension
+            val baseDirectory = context.getExternalFilesDir(null).toString() + File.separator + directory
+            if(!File(baseDirectory).exists()) { File(baseDirectory).mkdir() }
+
+            val newFilePath = baseDirectory + File.separator + System.currentTimeMillis() + '.' + extension
             val newFile = File(newFilePath)
 
             val inputStream = context.contentResolver.openInputStream(uri)
@@ -28,8 +31,11 @@ class ServerUtil {
             return newFile.absolutePath
         }
 
-        fun createCopyAndReturnRealPathServer(context: Context, byteArray: ByteArray, extension: String): String {
-            val newFilePath = context.applicationInfo.dataDir + File.separator +System.currentTimeMillis() + '.' + extension
+        fun createCopyAndReturnRealPathServer(context: Context, byteArray: ByteArray, extension: String, directory: String): String {
+            val baseDirectory = context.getExternalFilesDir(null).toString() + File.separator + directory
+            if(!File(baseDirectory).exists()) { File(baseDirectory).mkdir() }
+
+            val newFilePath = baseDirectory + File.separator + System.currentTimeMillis() + '.' + extension
             val newFile = File(newFilePath)
 
             val outputStream = FileOutputStream(newFile)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -107,8 +107,7 @@ class CommunityFragment : Fragment() {
         isViewDestroyed = true
 
         // Delete saved files
-        val dir = File(requireContext().getExternalFilesDir(null).toString() + "/pet_management")
-        dir.deleteRecursively()
+        Util.deleteCopiedFiles(requireContext(), COMMUNITY_DIRECTORY)
     }
 
     private fun initializeAdapter(){

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -51,6 +51,9 @@ class CommunityFragment : Fragment() {
     private var _binding: FragmentCommunityBinding? = null
     private val binding get() = _binding!!
 
+    // constant variables
+    private var COMMUNITY_DIRECTORY: String = "community"
+
     // session manager for user token
     private lateinit var sessionManager: SessionManager
 
@@ -210,7 +213,8 @@ class CommunityFragment : Fragment() {
                             // 영상
                             if(Util.isUrlVideo(url)){
                                 // Save file
-                                val dir = File(requireContext().getExternalFilesDir(null).toString() + "/pet_management")
+                                val dir = File(requireContext().getExternalFilesDir(null).toString() +
+                                        File.separator + COMMUNITY_DIRECTORY)
                                 if(! dir.exists()){
                                     dir.mkdir()
                                 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -997,9 +997,7 @@ class CreateUpdatePostFragment : Fragment() {
 
         // delete copied files(if any)
         if(isRemoving || requireActivity().isFinishing) {
-            for(path in createUpdatePostViewModel.photoVideoPathList) {
-                File(path).delete()
-            }
+            Util.deleteCopiedFiles(requireContext(), CREATE_UPDATE_POST_DIRECTORY)
         }
 
         // show message + return to previous activity
@@ -1040,9 +1038,7 @@ class CreateUpdatePostFragment : Fragment() {
 
         // delete copied files(if any)
         if(isRemoving || requireActivity().isFinishing) {
-            for(path in createUpdatePostViewModel.photoVideoPathList) {
-                File(path).delete()
-            }
+            Util.deleteCopiedFiles(requireContext(), CREATE_UPDATE_POST_DIRECTORY)
         }
 
         // stop api call when fragment is destroyed

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -59,6 +59,7 @@ class CreateUpdatePostFragment : Fragment() {
     private var DISCLOSURE_PUBLIC: String = "PUBLIC"
     private var DISCLOSURE_PRIVATE: String = "PRIVATE"
     private var DISCLOSURE_FRIEND: String = "FRIEND"
+    private var CREATE_UPDATE_POST_DIRECTORY: String = "create_update_post"
 
     // variable for ViewModel
     private val createUpdatePostViewModel: CreateUpdatePostViewModel by activityViewModels()
@@ -296,7 +297,7 @@ class CreateUpdatePostFragment : Fragment() {
                 if(data != null) {
                     // copy selected photo and get real path
                     createUpdatePostViewModel.photoVideoPathList
-                        .add(ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(), data.data!!))
+                        .add(ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(), data.data!!, CREATE_UPDATE_POST_DIRECTORY))
 
                     // create bytearray
                     val bitmap = BitmapFactory.decodeFile(createUpdatePostViewModel.photoVideoPathList.last())
@@ -324,7 +325,7 @@ class CreateUpdatePostFragment : Fragment() {
                 if(data != null) {
                     // copy selected photo and get real path
                     createUpdatePostViewModel.photoVideoPathList
-                        .add(ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(), data.data!!))
+                        .add(ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(), data.data!!, CREATE_UPDATE_POST_DIRECTORY))
 
                     // save thumbnail
                     createUpdatePostViewModel.thumbnailList.add(null)
@@ -854,7 +855,7 @@ class CreateUpdatePostFragment : Fragment() {
                         // copy file and get real path
                         val mediaByteArray = response.body()!!.byteStream().readBytes()
                         createUpdatePostViewModel.photoVideoPathList[index] =
-                            ServerUtil.createCopyAndReturnRealPathServer(context!!, mediaByteArray, extension)
+                            ServerUtil.createCopyAndReturnRealPathServer(context!!, mediaByteArray, extension, CREATE_UPDATE_POST_DIRECTORY)
 
                         // check if image and save thumbnail(video thumbnails are created in the RecyclerView adapter)
                         if("image" in MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)!!) {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -40,6 +40,7 @@ class EditAccountFragment : Fragment() {
 
     // constant variables
     private val PICK_PHOTO = 0
+    private var EDIT_ACCOUNT_DIRECTORY: String = "edit_account"
 
     private lateinit var editAccountViewModel: EditAccountViewModel
     private var _binding: FragmentEditAccountBinding? = null
@@ -527,7 +528,8 @@ class EditAccountFragment : Fragment() {
                 }
 
                 // copy selected photo and get real path
-                myPageViewModel.accountPhotoPathValue = ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(), data.data!!)
+                myPageViewModel.accountPhotoPathValue = ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(),
+                    data.data!!, EDIT_ACCOUNT_DIRECTORY)
 
                 // set photo to view
                 binding.accountPhotoInput.setImageBitmap(BitmapFactory.decodeFile(myPageViewModel.accountPhotoPathValue))

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -285,7 +285,7 @@ class EditAccountFragment : Fragment() {
 
         // delete copied file(if any)
         if(isRemoving || requireActivity().isFinishing) {
-            File(myPageViewModel.accountPhotoPathValue).delete()
+            Util.deleteCopiedFiles(requireContext(), EDIT_ACCOUNT_DIRECTORY)
         }
 
         updateAccountApiCall?.cancel()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -574,7 +574,7 @@ class CreateUpdatePetFragment : Fragment() {
 
         // delete copied file(if any)
         if(isRemoving || requireActivity().isFinishing) {
-            File(myPetViewModel.petPhotoPathValue).delete()
+            Util.deleteCopiedFiles(requireContext(), CREATE_UPDATE_PET_DIRECTORY)
         }
 
         // stop api call when fragment is destroyed

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -40,6 +40,7 @@ class CreateUpdatePetFragment : Fragment() {
 
     // constant variables
     private val PICK_PHOTO = 0
+    private var CREATE_UPDATE_PET_DIRECTORY: String = "create_update_pet"
 
     // variables for view binding
     private var _binding: FragmentCreateUpdatePetBinding? = null
@@ -558,7 +559,8 @@ class CreateUpdatePetFragment : Fragment() {
                 }
 
                 // copy selected photo and get real path
-                myPetViewModel.petPhotoPathValue = ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(), data.data!!)
+                myPetViewModel.petPhotoPathValue = ServerUtil.createCopyAndReturnRealPathLocal(requireActivity(),
+                    data.data!!, CREATE_UPDATE_PET_DIRECTORY)
 
                 // set photo to view
                 binding.petPhotoInput.setImageBitmap(BitmapFactory.decodeFile(myPetViewModel.petPhotoPathValue))


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [X] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
안드로이드 Client의 임시파일 생성/삭제 과정을 통일하였습니다.

> **본 PR의 작업 목적**
예외로 인하여 임시파일의 삭제가 제대로 이루어지지 않는 경우가 발생하는데, 이를 위해 추후에 임시파일 삭제 기능을 추가할 예정입니다. 해당 기능의 구현을 대비하여 임시파일 생성/삭제 과정의 통일이 필요하다고 판단했습니다.

## 변경사항
- 기존의 내부 저장소에 저장되던 방식을 외부 저장소에 저장하는 방식으로 통일
    - 외부 저장소(Android/data/com.sju18001.petmanagement/files/)에 임시파일 저장이 필요한 프래그먼트의 이름을 따 폴더를 생성하고, 해당 폴더에 임시파일을 저장
        - 예) 펫 추가 화면에서 사진을 선택 시, "create_update_pet" 라는 폴더가 생성되고, 그 폴더에 임시파일을 저장
    - ServerUtil.kt의 createCopyAndReturnRealPathLocal(), createCopyAndReturnRealPathServer()를 이용
        - 폴더명 관련 파라미터 및 로직 추가
- 임시파일 삭제 시, 해당 폴더 전체를 삭제하는 방식으로 통일
    - 예) 펫 추가 화면의 작업이 끝난 후 임시파일을 삭제할 때, "create_update_pet" 폴더를 삭제
    - Util.kt에 deleteCopiedFiles()함수 이용
- 커뮤니티 프래그먼트에서 동영상 파일의 임시 파일 생성은 파일명을 지정하는 방식이 특수하기 때문에, ServerUtil.kt의 함수를 사용하지 않고, 폴더 경로 관련 코드만 수정(삭제는 위 방법으로 통일)

## 비고
특이사항 없음.

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [X] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [X] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [X] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [X] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [X] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [X] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
