### PR TITLE
[Feature/photo-url-deletion] Account, Pet의 photoUrl 제거 기능 구현

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/dto/AccountDto.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/dto/AccountDto.kt
@@ -70,6 +70,7 @@ data class UpdateAccountReqDto(
     val phone: String,
     val nickname: String?,
     val marketing: Boolean?,
+    val photoUrl: String?,
     val userMessage: String?
 )
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/dto/PetProfileDto.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/dto/PetProfileDto.kt
@@ -37,7 +37,8 @@ data class UpdatePetReqDto (
     val birth: String?,
     val yearOnly: Boolean?,
     val gender: Boolean?,
-    val message: String?
+    val message: String?,
+    val photoUrl: String?
     )
 
 data class UpdatePetResDto (

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -190,7 +190,7 @@ class LoginFragment : Fragment() {
                         // 첫 로그인일 시
                         if(it.nickname == "#"){
                             // nickname => username 변경
-                            val updateAccountReqDto = UpdateAccountReqDto(it.email, it.phone, it.username, it.marketing, it.userMessage)
+                            val updateAccountReqDto = UpdateAccountReqDto(it.email, it.phone, it.username, it.marketing, it.photoUrl, it.userMessage)
 
                             val call = RetrofitBuilder.getServerApiWithToken(token).updateAccountReq(updateAccountReqDto)
                             call.enqueue(object: Callback<UpdateAccountResDto> {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -136,6 +136,11 @@ class MyPageFragment : Fragment() {
 
     // fetch account photo
     private fun fetchAccountPhotoAndSetView() {
+        if(accountData.photoUrl == null){
+            binding.accountPhoto.setImageDrawable(requireActivity().getDrawable(R.drawable.ic_baseline_account_circle_36))
+            return
+        }
+
         // create DTO
         val fetchAccountPhotoReqDto = FetchAccountPhotoReqDto(null)
 
@@ -155,9 +160,7 @@ class MyPageFragment : Fragment() {
                         // get error message + show(Toast)
                         val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
 
-                        // if null: set to default image
                         // Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                        binding.accountPhoto.setImageDrawable(requireActivity().getDrawable(R.drawable.ic_baseline_account_circle_36))
 
                         // log error message
                         Log.d("error", errorMessage)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -66,7 +66,7 @@ class MyPageFragment : Fragment() {
             accountLookupIntent.putExtra("nickname", accountData.nickname)
             accountLookupIntent.putExtra("userMessage", accountData.userMessage)
 
-            if(accountData.photoUrl != null) {
+            if(!accountData.photoUrl.isNullOrEmpty()) {
                 accountLookupIntent.putExtra("photoByteArray", myPageViewModel.accountPhotoProfileByteArray)
             }
 
@@ -136,7 +136,7 @@ class MyPageFragment : Fragment() {
 
     // fetch account photo
     private fun fetchAccountPhotoAndSetView() {
-        if(accountData.photoUrl == null){
+        if(accountData.photoUrl.isNullOrEmpty()){
             binding.accountPhoto.setImageDrawable(requireActivity().getDrawable(R.drawable.ic_baseline_account_circle_36))
             return
         }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -298,7 +298,7 @@ class EditAccountFragment : Fragment() {
     private fun updateAccount() {
         // Set photoUrl
         val prevAccount = SessionManager.fetchLoggedInAccount(requireContext())!!
-        val photoUrl = if(myPageViewModel.accountPhotoPathValue == "") null else prevAccount.photoUrl
+        val photoUrl = if(myPageViewModel.accountPhotoPathValue == "") "" else prevAccount.photoUrl
 
         // Create dto
         val updateAccountReqDto = UpdateAccountReqDto(

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -122,7 +122,9 @@ class EditAccountFragment : Fragment() {
             dialog.findViewById<Button>(R.id.use_default_image).setOnClickListener {
                 dialog.dismiss()
 
-                // TODO: Account photo delete API implement
+                binding.accountPhotoInput.setImageDrawable(requireActivity().getDrawable(R.drawable.ic_baseline_account_circle_36))
+                myPageViewModel.accountPhotoByteArray = null
+                myPageViewModel.accountPhotoPathValue = ""
             }
         }
 
@@ -294,14 +296,20 @@ class EditAccountFragment : Fragment() {
 
     // update account
     private fun updateAccount() {
-        // create dto
+        // Set photoUrl
+        val prevAccount = SessionManager.fetchLoggedInAccount(requireContext())!!
+        val photoUrl = if(myPageViewModel.accountPhotoPathValue == "") null else prevAccount.photoUrl
+
+        // Create dto
         val updateAccountReqDto = UpdateAccountReqDto(
             myPageViewModel.accountEmailValue,
             myPageViewModel.accountPhoneValue,
             myPageViewModel.accountNicknameValue,
             myPageViewModel.accountMarketingValue,
+            photoUrl,
             myPageViewModel.accountUserMessageValue
         )
+
 
         updateAccountApiCall = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updateAccountReq(updateAccountReqDto)
@@ -315,10 +323,9 @@ class EditAccountFragment : Fragment() {
                         updateAccountPhoto(myPageViewModel.accountPhotoPathValue)
 
                         // 세션 갱신
-                        val prevAccount = SessionManager.fetchLoggedInAccount(requireContext())!!
                         val account = Account(
                             prevAccount.id, prevAccount.username, myPageViewModel.accountEmailValue, myPageViewModel.accountPhoneValue, null,
-                            myPageViewModel.accountMarketingValue, myPageViewModel.accountNicknameValue, prevAccount.photoUrl, myPageViewModel.accountUserMessageValue
+                            myPageViewModel.accountMarketingValue, myPageViewModel.accountNicknameValue, photoUrl, myPageViewModel.accountUserMessageValue
                         )
                         SessionManager.saveLoggedInAccount(requireContext(), account)
                     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/MyPetViewModel.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/MyPetViewModel.kt
@@ -130,6 +130,11 @@ class MyPetViewModel(private val handle: SavedStateHandle) : ViewModel() {
             handle.set("petBirthIsYearOnlyValue", value)
             field = value
         }
+    var petPhotoUrlValue = handle.get<String>("petPhotoUrlValue")?: ""
+        set(value){
+            handle.set("petPhotoUrlValue", value)
+            field = value
+        }
     var petManagerApiIsLoading = handle.get<Boolean>("petManagerApiIsLoading")?: false
         set(value) {
             handle.set("petManagerApiIsLoading", value)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -1,5 +1,6 @@
 package com.sju18001.petmanagement.ui.myPet.petManager
 
+import android.app.Dialog
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -12,6 +13,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
+import android.widget.Button
+import android.widget.ImageView
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
@@ -95,10 +99,28 @@ class CreateUpdatePetFragment : Fragment() {
 
         // for pet photo picker
         binding.petPhotoInputButton.setOnClickListener {
-            val intent = Intent()
-            intent.type = "image/*"
-            intent.action = Intent.ACTION_GET_CONTENT
-            startActivityForResult(Intent.createChooser(intent, "사진 선택"), PICK_PHOTO)
+            val dialog = Dialog(requireActivity())
+            dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+            dialog.setContentView(R.layout.select_account_photo_dialog)
+            dialog.show()
+
+            dialog.findViewById<ImageView>(R.id.close_button2).setOnClickListener { dialog.dismiss() }
+            dialog.findViewById<Button>(R.id.upload_photo_button).setOnClickListener {
+                dialog.dismiss()
+
+                val intent = Intent()
+                intent.type = "image/*"
+                intent.action = Intent.ACTION_GET_CONTENT
+                startActivityForResult(Intent.createChooser(intent, "사진 선택"), PICK_PHOTO)
+            }
+            dialog.findViewById<Button>(R.id.use_default_image).setOnClickListener {
+                dialog.dismiss()
+
+                binding.petPhotoInput.setImageDrawable(requireActivity().getDrawable(R.drawable.ic_baseline_pets_60_with_padding))
+                myPetViewModel.petPhotoByteArray = null
+                myPetViewModel.petPhotoPathValue = ""
+                myPetViewModel.petPhotoUrlValue = ""
+            }
         }
 
         // for EditText text change listeners
@@ -286,7 +308,8 @@ class CreateUpdatePetFragment : Fragment() {
             petBirthStringValue,
             binding.yearOnlyCheckbox.isChecked,
             binding.genderFemale.isChecked,
-            binding.petMessageInput.text.toString()
+            binding.petMessageInput.text.toString(),
+            myPetViewModel.petPhotoUrlValue
         )
 
         updatePetApiCall = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -309,7 +309,7 @@ class CreateUpdatePetFragment : Fragment() {
             binding.yearOnlyCheckbox.isChecked,
             binding.genderFemale.isChecked,
             binding.petMessageInput.text.toString(),
-            myPetViewModel.petPhotoUrlValue
+            myPetViewModel.petPhotoUrlValue?:""
         )
 
         updatePetApiCall = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
@@ -70,7 +70,7 @@ class PetListAdapter(private val startDragListener: OnStartDragListener, private
         }
 
         // set values to views
-        if(currentItem.getPetPhotoUrl() != null) {
+        if(!currentItem.getPetPhotoUrl().isNullOrEmpty()) {
             fetchPetPhoto(currentItem.getPetId()!!, holder.petPhoto)
         }
         else {
@@ -89,7 +89,7 @@ class PetListAdapter(private val startDragListener: OnStartDragListener, private
         holder.itemView.setOnClickListener {
             // set pet values to Intent
             val petProfileIntent = Intent(holder.itemView.context, MyPetActivity::class.java)
-            if(currentItem.getPetPhotoUrl() != null) {
+            if(!currentItem.getPetPhotoUrl().isNullOrEmpty()) {
                 val bitmap = (holder.petPhoto.drawable as BitmapDrawable).bitmap
                 val stream = ByteArrayOutputStream()
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)

--- a/server/src/main/java/com/sju18/petmanagement/domain/account/application/AccountService.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/account/application/AccountService.java
@@ -161,6 +161,9 @@ public class AccountService {
         if (reqDto.getNickname() != null && !reqDto.getNickname().equals(currentAccount.getNickname())) {
             currentAccount.setNickname(reqDto.getNickname());
         }
+        if (reqDto.getPhotoUrl() != null && !reqDto.getPhotoUrl().equals(currentAccount.getPhotoUrl())) {
+            currentAccount.setPhotoUrl(reqDto.getPhotoUrl());
+        }
         if (reqDto.getUserMessage() != null && !reqDto.getUserMessage().equals(currentAccount.getUserMessage())) {
             currentAccount.setUserMessage(reqDto.getUserMessage());
         }

--- a/server/src/main/java/com/sju18/petmanagement/domain/account/dto/UpdateAccountReqDto.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/account/dto/UpdateAccountReqDto.java
@@ -16,6 +16,7 @@ public class UpdateAccountReqDto {
     private String phone;
     @Size(max = 20, message = "valid.account.nickname.size")
     private String nickname;
+    private String photoUrl;
     private Boolean marketing;
     @Size(max = 200, message = "valid.account.userMessage.size")
     private String userMessage;

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/application/PetService.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/application/PetService.java
@@ -134,6 +134,9 @@ public class PetService {
         if (reqDto.getMessage() != null && !reqDto.getMessage().equals(currentPet.getMessage())) {
             currentPet.setMessage(reqDto.getMessage());
         }
+        if (reqDto.getPhotoUrl() != null && !reqDto.getPhotoUrl().equals(currentPet.getPhotoUrl())) {
+            currentPet.setPhotoUrl(reqDto.getPhotoUrl());
+        }
 
         // save(id가 있는 detached 상태의 객체) -> EntityManger.merge() => update
         petRepository.save(currentPet);

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/dto/UpdatePetReqDto.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/dto/UpdatePetReqDto.java
@@ -21,4 +21,5 @@ public class UpdatePetReqDto {
     private Boolean yearOnly;
     private Boolean gender;
     private String message;
+    private String photoUrl;
 }

--- a/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
+++ b/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
@@ -25,7 +25,7 @@ import java.util.*;
 @Service
 public class FileService {
     private final MessageSource msgSrc = MessageConfig.getStorageMessageSource();
-    private final String storageRootPath = "D:\\TempDev\\Pet-Management\\storage";
+    private final String storageRootPath = "C:\\Users\\fchop\\Development\\tmp\\Pet-Management\\storage";
 
     // 파일 메타데이터 목록(stringify 된 JSON)을 이용하여 파일 읽기
     public byte[] readFileFromFileMetadataListJson(String fileMetadataListJson, Integer fileIndex) throws IOException {


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
Account, Pet에서 '기본 이미지'를 클릭하여 사진을 제거할 수 있는 기능을 구현하였습니다.

## 변경사항
 - 서버, 클라이언트의 UpdateAccountReq, UpdatePetReq에 photoUrl을 추가하였습니다.
 - Update Response에 photoUrl을 추가하였으므로, 사진을 변경하지 않고, 다른 정보만을 업데이트할 때, 이에 대한 조치가 필요하였습니다.
     - Account에서는, SessionManager를 통해 어카운트 세션의 photoUrl를 참조하여 가져옵니다.
     - Pet에서는, ViewModel에 petPhotoUrlValue을 추가하여 이를 해결하였습니다.
 - Account, Pet의 Update를 할 때, '기본 이미지' 버튼을 눌러 photoUrl을 empty로 초기화합니다.
     - Account에서는 myPageViewModel.accountPhotoPathValue가 비었다면(기본 이미지 버튼을 누르면 empty 값을 갖게 됩니다.) empty값을 dto에 넣습니다.
     - Pet에서는 위에서 언급한 myPetViewModel.petPhotoUrlValue에 empty값을 넣어주고, 이 값을 updatePetReqDto에 넣어줍니다.
 
## 비고

https://user-images.githubusercontent.com/58168528/132019149-208f16e4-29ec-413f-8a0d-c93b6d9cd97b.mp4


## 품질 관리를 위한 체크리스트
 - [x] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
