### PR TITLE
[Feature/post-media-delete] PostMediaDelete 구현

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
@@ -19,7 +19,9 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import com.google.gson.Gson
 import com.sju18001.petmanagement.restapi.Place
+import com.sju18001.petmanagement.restapi.global.FileMetaData
 import okhttp3.ResponseBody
 import org.json.JSONObject
 import java.io.File
@@ -188,6 +190,10 @@ class Util {
             }
 
             return result
+        }
+
+        fun getArrayFromMediaAttachments(mediaAttachments: String?): Array<FileMetaData>{
+            return if (mediaAttachments != null) Gson().fromJson(mediaAttachments, Array<FileMetaData>::class.java) else arrayOf()
         }
     }
 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerApi.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerApi.kt
@@ -119,6 +119,8 @@ interface ServerApi {
     @POST("api/post/media/update")
     fun updatePostMediaReq(@Part("id") id: Long, @Part fileList: List<MultipartBody.Part>): Call<UpdatePostMediaResDto>
 
+    @POST("api/post/media/delete")
+    fun deletePostMediaReq(@Body deletePostMediaReqDto: DeletePostMediaReqDto): Call<DeletePostMediaResDto>
 
     // Follow API
     @POST("api/community/follower/fetch")

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/dto/PostDto.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/dto/PostDto.kt
@@ -65,3 +65,11 @@ data class UpdatePostMediaResDto (
     val _metadata: DtoMetadata,
     val fileMetadataList: List<FileMetaData>
 )
+
+data class DeletePostMediaReqDto (
+    val id: Long
+)
+
+data class DeletePostMediaResDto (
+    val _metadata: DtoMetadata
+)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -267,11 +267,11 @@ class CommunityFragment : Fragment() {
                 })
             }
 
-            override fun onClickPostFunctionButton(postId: Long, authorId: Long, position: Int) {
+            override fun onClickPostFunctionButton(post: Post, position: Int) {
                 val loggedInAccount = SessionManager.fetchLoggedInAccount(requireContext())!!
 
-                if(loggedInAccount.id == authorId){
-                    createPostDialogForAuthor(postId, position)
+                if(loggedInAccount.id == post.author.id){
+                    createPostDialogForAuthor(post, position)
                 }else{
                     createPostDialogForNonAuthor()
                 }
@@ -537,7 +537,7 @@ class CommunityFragment : Fragment() {
     }
 
 
-    private fun createPostDialogForAuthor(postId: Long, position: Int){
+    private fun createPostDialogForAuthor(post: Post, position: Int){
         val builder = AlertDialog.Builder(requireActivity())
         builder.setItems(arrayOf("수정", "삭제"), DialogInterface.OnClickListener{ _, which ->
             when(which){
@@ -545,8 +545,9 @@ class CommunityFragment : Fragment() {
                     // 수정
                     val createUpdatePostActivityIntent = Intent(context, CreateUpdatePostActivity::class.java)
                     createUpdatePostActivityIntent.putExtra("fragmentType", "update_post")
-                    createUpdatePostActivityIntent.putExtra("postId", postId)
+                    createUpdatePostActivityIntent.putExtra("postId", post.id)
                     createUpdatePostActivityIntent.putExtra("position", position)
+                    createUpdatePostActivityIntent.putExtra("originalMediaCount", Util.getArrayFromMediaAttachments(post.mediaAttachments).size)
 
                     startForUpdateResult.launch(createUpdatePostActivityIntent)
                     requireActivity().overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left)
@@ -556,7 +557,7 @@ class CommunityFragment : Fragment() {
                     val builder = AlertDialog.Builder(requireActivity())
                     builder.setMessage(getString(R.string.delete_post_dialog))
                         .setPositiveButton(R.string.confirm,
-                            DialogInterface.OnClickListener { _, _ -> deletePost(postId, position) }
+                            DialogInterface.OnClickListener { _, _ -> deletePost(post.id, position) }
                         )
                         .setNegativeButton(R.string.cancel,
                             DialogInterface.OnClickListener { dialog, _ -> dialog.cancel() }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityPostListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityPostListAdapter.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.ViewPager2
 import com.google.gson.Gson
 import com.sju18001.petmanagement.R
+import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.restapi.global.FileMetaData
 import de.hdodenhof.circleimageview.CircleImageView
 
@@ -21,7 +22,7 @@ interface CommunityPostListAdapterInterface{
     fun startCommunityCommentActivity(postId: Long)
     fun createLike(postId: Long, holder: CommunityPostListAdapter.ViewHolder, position: Int)
     fun deleteLike(postId: Long, holder: CommunityPostListAdapter.ViewHolder, position: Int)
-    fun onClickPostFunctionButton(postId: Long, authorId: Long, position: Int)
+    fun onClickPostFunctionButton(post: Post, position: Int)
     fun setAccountPhoto(id: Long, holder: CommunityPostListAdapter.ViewHolder)
     fun setAccountDefaultPhoto(holder: CommunityPostListAdapter.ViewHolder)
     fun setPostMedia(holder: CommunityPostListAdapter.PostMediaItemCollectionAdapter.ViewPagerHolder, id: Long, index: Int, url: String)
@@ -97,7 +98,7 @@ class CommunityPostListAdapter(private var dataSet: ArrayList<Post>, private var
 
     private fun setViewPager(holder: ViewHolder, data: Post){
         if(!data.mediaAttachments.isNullOrEmpty()){
-            val mediaAttachments: Array<FileMetaData> = Gson().fromJson(data.mediaAttachments, Array<FileMetaData>::class.java)
+            val mediaAttachments = Util.getArrayFromMediaAttachments(data.mediaAttachments)
 
             holder.viewPager.adapter = CommunityPostListAdapter.PostMediaItemCollectionAdapter(communityPostListAdapterInterface, data.id, mediaAttachments, holder.viewPager)
             holder.viewPager.orientation = ViewPager2.ORIENTATION_HORIZONTAL
@@ -164,7 +165,7 @@ class CommunityPostListAdapter(private var dataSet: ArrayList<Post>, private var
 
         // ... 버튼 -> Dialog 띄우기
         holder.dialogButton.setOnClickListener {
-            communityPostListAdapterInterface.onClickPostFunctionButton(dataSet[position].id, dataSet[position].author.id, position)
+            communityPostListAdapterInterface.onClickPostFunctionButton(dataSet[position], position)
         }
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -698,6 +698,10 @@ class CreateUpdatePostFragment : Fragment() {
                 call: Call<UpdatePostResDto>,
                 response: Response<UpdatePostResDto>
             ) {
+                if(isViewDestroyed){
+                    return
+                }
+
                 if (response.isSuccessful) {
                     // no media files
                     if(createUpdatePostViewModel.photoVideoPathList.size == 0) {
@@ -727,14 +731,13 @@ class CreateUpdatePostFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<UpdatePostResDto>, t: Throwable) {
+                if(isViewDestroyed){
+                    return
+                }
+
                 // set api state/button to normal
                 createUpdatePostViewModel.apiIsLoading = false
                 setButtonToNormal()
-
-                // if the view was destroyed(API call canceled) -> return
-                if (_binding == null) {
-                    return
-                }
 
                 // show(Toast)/log error message
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()

--- a/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
+++ b/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
@@ -25,7 +25,7 @@ import java.util.*;
 @Service
 public class FileService {
     private final MessageSource msgSrc = MessageConfig.getStorageMessageSource();
-    private final String storageRootPath = "C:\\Users\\Komputer\\Pet-Management-Storage";
+    private final String storageRootPath = "C:\\Users\\fchop\\Development\\tmp\\Pet-Management\\storage";
     private final Integer MEDIA_FILE = 1;
     private final Integer GENERAL_FILE = 2;
 


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
PostMediaDelete를 구현하였습니다.

## 변경사항
 - 구현을 위한 ServerApi, PostDto의 수정
 - updatePost()에서 api call을 마치면 경우에 따라 deletePostMedia()를 수행합니다. 이 때의 조건은 **수정하기 전 Media의 갯수가 1개 이상일 때**입니다. 만약 이 조건문이 붙지 않고, media file이 없는 것만 감지하였다면, 원래부터 media가 없는 글을 수정할 때 null pointer exception이 발생합니다. 따라서 이것을 감지하기 위해, 글 수정을 위해 액티비티를 시작하기 전에 intent에 "originalMediaCount"를 넣어주었습니다.
 - Util.kt에 getArrayFromMediaAttachments()를 추가하였습니다. String 타입의 mediaAttachments를 배열화하여 반환하는 기능을 수행합니다.
 
## 비고


https://user-images.githubusercontent.com/58168528/132840486-1a239c09-b761-4928-ac24-b0ba3871e9f8.mp4



## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
