### PR TITLE
[Feature/unification-of-api-call-error-message] API call의 오류 메시지 출력의 통일성 강화

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/MainActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/MainActivity.kt
@@ -118,9 +118,8 @@ class MainActivity : AppCompatActivity() {
         fragmentManager.beginTransaction().show(activeFragment).commitNow()
 
         navView.setOnNavigationItemSelectedListener {
-            // 커뮤니티 -> 다른 탭 이동 시
+            // 커뮤니티에서 다른 탭으로 이동 시
             if(activeFragment.tag == "community"){
-                // 모든 비디오 재생 중지
                 (activeFragment as CommunityFragment).pauseAllVideos()
             }
 
@@ -167,8 +166,7 @@ class MainActivity : AppCompatActivity() {
 
                     activeFragmentIndex = 2
                     activeFragment = communityFragment
-                    
-                    // 모든 동영상 재생
+
                     (activeFragment as CommunityFragment).startAllVideos()
 
                     true
@@ -191,8 +189,7 @@ class MainActivity : AppCompatActivity() {
             }
             false
         }
-        
-        // 모든 알람 취소하고, PetSchedule에 따라 알림 등록
+
         synchronizeNotificationWorkManager()
     }
 
@@ -256,7 +253,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun synchronizeNotificationWorkManager(){
-        // 모든 알림 취소
         PetScheduleNotification.cancelAllWorkManager(applicationContext)
         
         // PetSchedule Fetch한 뒤, 알림 등록

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/controller/Util.kt
@@ -195,5 +195,17 @@ class Util {
         fun getArrayFromMediaAttachments(mediaAttachments: String?): Array<FileMetaData>{
             return if (mediaAttachments != null) Gson().fromJson(mediaAttachments, Array<FileMetaData>::class.java) else arrayOf()
         }
+
+        fun showToastAndLogForFailedResponse(context: Context, errorBody: ResponseBody?){
+            if(errorBody == null) return
+
+            val errorMessage = getMessageFromErrorBody(errorBody)
+            showToastAndLog(context, errorMessage)
+        }
+
+        fun showToastAndLog(context: Context, message: String){
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            Log.d("error", message)
+        }
     }
 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerUtil.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerUtil.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import android.webkit.MimeTypeMap
+import android.widget.Toast
 import java.io.File
 import java.io.FileOutputStream
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -124,9 +124,7 @@ class CommunityFragment : Fragment() {
                 call: Call<FetchPostResDto>,
                 response: Response<FetchPostResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     response.body()?.postList?.get(0)?.let{ item ->
@@ -136,9 +134,7 @@ class CommunityFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<FetchPostResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
             }
@@ -210,9 +206,7 @@ class CommunityFragment : Fragment() {
                         call: Call<CreateLikeResDto>,
                         response: Response<CreateLikeResDto>
                     ) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         if(response.isSuccessful){
                             holder.likeCountTextView.text = ((holder.likeCountTextView.text).toString().toLong() + 1).toString()
@@ -226,9 +220,7 @@ class CommunityFragment : Fragment() {
                     }
 
                     override fun onFailure(call: Call<CreateLikeResDto>, t: Throwable) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         Toast.makeText(requireContext(), t.message, Toast.LENGTH_SHORT).show()
                     }
@@ -243,9 +235,7 @@ class CommunityFragment : Fragment() {
                         call: Call<DeleteLikeResDto>,
                         response: Response<DeleteLikeResDto>
                     ) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         if(response.isSuccessful){
                             holder.likeCountTextView.text = ((holder.likeCountTextView.text).toString().toLong() - 1).toString()
@@ -259,9 +249,7 @@ class CommunityFragment : Fragment() {
                     }
 
                     override fun onFailure(call: Call<DeleteLikeResDto>, t: Throwable) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         Toast.makeText(requireContext(), t.message, Toast.LENGTH_SHORT).show()
                     }
@@ -283,9 +271,7 @@ class CommunityFragment : Fragment() {
                     .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
                 call.enqueue(object: Callback<ResponseBody> {
                     override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         if(response.isSuccessful) {
                             // convert photo to byte array + get bitmap
@@ -330,9 +316,7 @@ class CommunityFragment : Fragment() {
                         call: Call<ResponseBody>,
                         response: Response<ResponseBody>
                     ) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         if(response.isSuccessful){
                             // 영상
@@ -418,9 +402,7 @@ class CommunityFragment : Fragment() {
                     }
 
                     override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         Toast.makeText(context, t.message, Toast.LENGTH_LONG).show()
                     }
@@ -459,9 +441,7 @@ class CommunityFragment : Fragment() {
                 call: Call<FetchPostResDto>,
                 response: Response<FetchPostResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     response.body()!!.postList?.let {
@@ -494,9 +474,7 @@ class CommunityFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<FetchPostResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
 
@@ -514,6 +492,8 @@ class CommunityFragment : Fragment() {
                 call: Call<FetchLikeResDto>,
                 response: Response<FetchLikeResDto>
             ) {
+                if(isViewDestroyed) return
+
                 if(response.isSuccessful){
                     adapter.setLikedCount(position, response.body()!!.likedCount!!)
 
@@ -581,9 +561,7 @@ class CommunityFragment : Fragment() {
                 call: Call<DeletePostResDto>,
                 response: Response<DeletePostResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     // 데이터셋에서 삭제
@@ -599,9 +577,7 @@ class CommunityFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<DeletePostResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message, Toast.LENGTH_LONG).show()
             }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -136,7 +136,7 @@ class CommunityFragment : Fragment() {
             override fun onFailure(call: Call<FetchPostResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -211,8 +211,7 @@ class CommunityFragment : Fragment() {
                         if(response.isSuccessful){
                             holder.likeCountTextView.text = ((holder.likeCountTextView.text).toString().toLong() + 1).toString()
                         }else{
-                            val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                            Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
 
                         adapter.setIsPostLiked(position, true)
@@ -222,7 +221,7 @@ class CommunityFragment : Fragment() {
                     override fun onFailure(call: Call<CreateLikeResDto>, t: Throwable) {
                         if(isViewDestroyed) return
 
-                        Toast.makeText(requireContext(), t.message, Toast.LENGTH_SHORT).show()
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -240,8 +239,7 @@ class CommunityFragment : Fragment() {
                         if(response.isSuccessful){
                             holder.likeCountTextView.text = ((holder.likeCountTextView.text).toString().toLong() - 1).toString()
                         }else{
-                            val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                            Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
 
                         adapter.setIsPostLiked(position, false)
@@ -251,7 +249,7 @@ class CommunityFragment : Fragment() {
                     override fun onFailure(call: Call<DeleteLikeResDto>, t: Throwable) {
                         if(isViewDestroyed) return
 
-                        Toast.makeText(requireContext(), t.message, Toast.LENGTH_SHORT).show()
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -282,18 +280,12 @@ class CommunityFragment : Fragment() {
                             holder.petPhotoImage.setImageBitmap(photoBitmap)
                         }
                         else {
-                            // get error message
-                            val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                            // Toast + Log
-                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                            Log.d("error", errorMessage)
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
 
                     override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                        // log error message
-                        Log.d("error", t.message.toString())
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -393,18 +385,14 @@ class CommunityFragment : Fragment() {
                                 postMediaImage.layoutParams.height = (photoBitmap.height.toFloat() * ratio).toInt()
                             }
                         }else{
-                            // get error message
-                            val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                            // Toast + Log
-                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
 
                     override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                         if(isViewDestroyed) return
 
-                        Toast.makeText(context, t.message, Toast.LENGTH_LONG).show()
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -466,7 +454,7 @@ class CommunityFragment : Fragment() {
                         }
                     }
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_LONG).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
 
                 // 새로고침 아이콘 제거
@@ -476,10 +464,10 @@ class CommunityFragment : Fragment() {
             override fun onFailure(call: Call<FetchPostResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-
                 // 새로고침 아이콘 제거
                 binding.layoutSwipeRefresh.isRefreshing = false
+
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -571,15 +559,14 @@ class CommunityFragment : Fragment() {
 
                     Toast.makeText(context, getString(R.string.delete_post_successful), Toast.LENGTH_LONG).show()
                 }else{
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<DeletePostResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message, Toast.LENGTH_LONG).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -63,7 +63,7 @@ class CommunityFragment : Fragment() {
     // 리싸이클러뷰
     private lateinit var adapter: CommunityPostListAdapter
 
-    private var isViewDestroyed: Boolean = false
+    private var isViewDestroyed = false
     
     // 글 새로고침
     private var topPostId: Long? = null
@@ -151,6 +151,7 @@ class CommunityFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentCommunityBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         // 어뎁터 초기화
         initializeAdapter()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -149,7 +149,6 @@ class CommunityFragment : Fragment() {
         _binding = FragmentCommunityBinding.inflate(inflater, container, false)
         isViewDestroyed = false
 
-        // 어뎁터 초기화
         initializeAdapter()
         
         // 초기 Post 추가
@@ -311,7 +310,6 @@ class CommunityFragment : Fragment() {
                         if(isViewDestroyed) return
 
                         if(response.isSuccessful){
-                            // 영상
                             if(Util.isUrlVideo(url)){
                                 // Save file
                                 val dir = File(requireContext().getExternalFilesDir(null).toString() +
@@ -457,14 +455,12 @@ class CommunityFragment : Fragment() {
                     Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
 
-                // 새로고침 아이콘 제거
                 binding.layoutSwipeRefresh.isRefreshing = false
             }
 
             override fun onFailure(call: Call<FetchPostResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // 새로고침 아이콘 제거
                 binding.layoutSwipeRefresh.isRefreshing = false
 
                 Util.showToastAndLog(requireContext(), t.message.toString())

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityPostListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityPostListAdapter.kt
@@ -61,10 +61,7 @@ class CommunityPostListAdapter(private var dataSet: ArrayList<Post>, private var
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val safePosition = holder.adapterPosition
 
-        // 데이터 동기화
         updateDataSetToViewHolder(holder, dataSet[safePosition], likedCounts[safePosition], safePosition)
-
-        // 리스너 추가
         setListenerOnView(holder, position)
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
@@ -65,7 +65,7 @@ class CommunityCommentFragment : Fragment() {
     // 리싸이클러뷰
     private lateinit var adapter: CommunityCommentListAdapter
 
-    private var isViewDestroyed: Boolean = false
+    private var isViewDestroyed = false
 
     // 댓글 새로고침
     private var topCommentId: Long? = null
@@ -82,6 +82,7 @@ class CommunityCommentFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentCommunityCommentBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         // postId 지정
         postId = requireActivity().intent.getLongExtra("postId", -1)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
@@ -152,9 +152,7 @@ class CommunityCommentFragment : Fragment() {
                         call: Call<FetchCommentResDto>,
                         response: Response<FetchCommentResDto>
                     ) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
                         
                         if(response.isSuccessful){
                             // Add replies to RecyclerView
@@ -182,9 +180,7 @@ class CommunityCommentFragment : Fragment() {
                     }
 
                     override fun onFailure(call: Call<FetchCommentResDto>, t: Throwable) {
-                        if(isViewDestroyed){
-                            return
-                        }
+                        if(isViewDestroyed) return
 
                         Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
                     }
@@ -266,9 +262,7 @@ class CommunityCommentFragment : Fragment() {
                 call: Call<DeleteCommentResDto>,
                 response: Response<DeleteCommentResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     Toast.makeText(context, context?.getText(R.string.delete_comment_success), Toast.LENGTH_SHORT).show()
@@ -282,9 +276,7 @@ class CommunityCommentFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<DeleteCommentResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
             }
@@ -306,9 +298,7 @@ class CommunityCommentFragment : Fragment() {
                 call: Call<FetchCommentResDto>,
                 response: Response<FetchCommentResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     response.body()!!.commentList?.let {
@@ -339,9 +329,7 @@ class CommunityCommentFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<FetchCommentResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
 
@@ -360,9 +348,7 @@ class CommunityCommentFragment : Fragment() {
                 call: Call<FetchCommentResDto>,
                 response: Response<FetchCommentResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     // 답글 불러오기 버튼
@@ -377,9 +363,7 @@ class CommunityCommentFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<FetchCommentResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
             }
@@ -435,9 +419,7 @@ class CommunityCommentFragment : Fragment() {
                 call: Call<CreateCommentResDto>,
                 response: Response<CreateCommentResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     // 새로고침
@@ -458,9 +440,7 @@ class CommunityCommentFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<CreateCommentResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
 
@@ -494,9 +474,7 @@ class CommunityCommentFragment : Fragment() {
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
         call.enqueue(object: Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful) {
                     // convert photo to byte array + get bitmap

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
@@ -174,15 +174,14 @@ class CommunityCommentFragment : Fragment() {
                                 adapter.notifyItemRangeInserted(position + 1, replyCount)
                             }
                         }else{
-                            val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                            Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
 
                     override fun onFailure(call: Call<FetchCommentResDto>, t: Throwable) {
                         if(isViewDestroyed) return
 
-                        Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -271,14 +270,14 @@ class CommunityCommentFragment : Fragment() {
                     adapter.notifyItemRemoved(position)
                     adapter.notifyItemRangeChanged(position, adapter.itemCount)
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_SHORT).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<DeleteCommentResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -321,7 +320,7 @@ class CommunityCommentFragment : Fragment() {
                         }
                     }
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_SHORT).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
 
                 // 새로고침 아이콘 제거
@@ -331,10 +330,10 @@ class CommunityCommentFragment : Fragment() {
             override fun onFailure(call: Call<FetchCommentResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
-
                 // 새로고침 아이콘 제거
                 binding.layoutSwipeRefresh.isRefreshing = false
+
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -357,15 +356,14 @@ class CommunityCommentFragment : Fragment() {
                         adapter.notifyItemChanged(position)
                     }
                 }else{
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchCommentResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -431,8 +429,7 @@ class CommunityCommentFragment : Fragment() {
                     binding.editTextComment.text = null
                     Toast.makeText(context, context?.getText(R.string.create_comment_success), Toast.LENGTH_SHORT).show()
                 }else{
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
 
                 setCommentInputToNormal()
@@ -442,10 +439,10 @@ class CommunityCommentFragment : Fragment() {
             override fun onFailure(call: Call<CreateCommentResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
-
                 setCommentInputToNormal()
                 setViewForReplyCancel()
+
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -485,18 +482,12 @@ class CommunityCommentFragment : Fragment() {
                     imageView.setImageBitmap(photoBitmap)
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentListAdapter.kt
@@ -58,13 +58,11 @@ class CommunityCommentListAdapter(
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        // 데이터 동기화
         updateDataSetToViewHolder(holder, dataSet[position], position)
         
         // 댓글 내용에 indent 추가
         setSpanToContent(holder.nicknameTextView, holder.contentsTextView)
-        
-        // 리스너 추가
+
         setListenerOnView(holder, position)
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
@@ -92,9 +92,7 @@ class UpdateCommentFragment : Fragment() {
                 call: Call<UpdateCommentResDto>,
                 response: Response<UpdateCommentResDto>
             ) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 if(response.isSuccessful){
                     // Pass datum for comment
@@ -115,9 +113,7 @@ class UpdateCommentFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<UpdateCommentResDto>, t: Throwable) {
-                if(isViewDestroyed){
-                    return
-                }
+                if(isViewDestroyed) return
 
                 setButtonToNormal()
                 Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
@@ -25,7 +25,7 @@ class UpdateCommentFragment : Fragment() {
     private var _binding: FragmentUpdateCommentBinding? = null
     private val binding get() = _binding!!
 
-    private var isViewDestroyed: Boolean = false
+    private var isViewDestroyed = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -33,6 +33,7 @@ class UpdateCommentFragment : Fragment() {
     ): View? {
         // Inflate the layout for this fragment
         _binding = FragmentUpdateCommentBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         // 초기화
         loadContents()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
@@ -105,10 +105,9 @@ class UpdateCommentFragment : Fragment() {
                     Toast.makeText(context, context?.getText(R.string.update_comment_success), Toast.LENGTH_SHORT).show()
                     activity?.finish()
                 }else{
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-
                     setButtonToNormal()
+
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -116,7 +115,8 @@ class UpdateCommentFragment : Fragment() {
                 if(isViewDestroyed) return
 
                 setButtonToNormal()
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_SHORT).show()
+
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -125,7 +125,6 @@ class CreateUpdatePostFragment : Fragment() {
                 binding.postDataLoadingLayout.visibility = View.VISIBLE
                 binding.confirmButton.isEnabled = false
 
-                // fetch post data
                 fetchPostData()
         }
 
@@ -143,7 +142,6 @@ class CreateUpdatePostFragment : Fragment() {
         // for post photo/video picker
         binding.uploadPhotosAndVideosButton.setOnClickListener {
             if(createUpdatePostViewModel.thumbnailList.size == 10) {
-                // show message(photo/video usage full)
                 Toast.makeText(context, context?.getText(R.string.photo_video_usage_full_message), Toast.LENGTH_LONG).show()
             }
             else {
@@ -239,11 +237,9 @@ class CreateUpdatePostFragment : Fragment() {
 
             if(createUpdatePostViewModel.thumbnailList.size == 0 &&
                 createUpdatePostViewModel.postEditText == "") {
-                // show message(post invalid)
                 Toast.makeText(context, context?.getText(R.string.post_invalid_message), Toast.LENGTH_LONG).show()
             }
             else if(createUpdatePostViewModel.petId == null) {
-                // show message(pet not selected)
                 Toast.makeText(context, context?.getText(R.string.pet_not_selected_message), Toast.LENGTH_LONG).show()
             }
             else {
@@ -261,7 +257,6 @@ class CreateUpdatePostFragment : Fragment() {
             activity?.finish()
         }
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentCreateUpdatePostParentLayout)
     }
 
@@ -294,11 +289,9 @@ class CreateUpdatePostFragment : Fragment() {
                     photoVideoAdapter.notifyItemInserted(createUpdatePostViewModel.thumbnailList.size)
                     binding.photosAndVideosRecyclerView.smoothScrollToPosition(createUpdatePostViewModel.thumbnailList.size - 1)
 
-                    // update photo/video usage
                     updatePhotoVideoUsage()
                 }
                 else {
-                    // show message(file null exception)
                     Toast.makeText(context, context?.getText(R.string.file_null_exception_message), Toast.LENGTH_LONG).show()
                 }
             }
@@ -315,16 +308,13 @@ class CreateUpdatePostFragment : Fragment() {
                     photoVideoAdapter.notifyItemInserted(createUpdatePostViewModel.thumbnailList.size)
                     binding.photosAndVideosRecyclerView.smoothScrollToPosition(createUpdatePostViewModel.thumbnailList.size - 1)
 
-                    // update photo/video usage
                     updatePhotoVideoUsage()
                 }
                 else {
-                    // show message(file null exception)
                     Toast.makeText(context, context?.getText(R.string.file_null_exception_message), Toast.LENGTH_LONG).show()
                 }
             }
             else -> {
-                // show message(file type exception)
                 Toast.makeText(context, context?.getText(R.string.file_type_exception_message), Toast.LENGTH_LONG).show()
             }
         }
@@ -355,10 +345,7 @@ class CreateUpdatePostFragment : Fragment() {
                         apiResponse.add(item)
                     }
 
-                    // reorder items
                     reorderPetList(apiResponse)
-
-                    // set spinner + photo
                     setPetSpinner()
                 }
                 else {
@@ -396,14 +383,10 @@ class CreateUpdatePostFragment : Fragment() {
                         binding.petPhotoCircleView.setImageBitmap(BitmapFactory.decodeStream(response.body()!!.byteStream()))
                     }
                     else {
-                        // get error message
-                        val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                        // if null -> set default
-                        if(errorMessage == "null") {
+                        if(Util.getMessageFromErrorBody(response.errorBody()!!) == "null") {
+                            // Set default
                             binding.petPhotoCircleView.setImageDrawable(requireContext().getDrawable(R.drawable.ic_baseline_pets_60_with_padding))
                         }
-                        // else -> show(Toast)/log error message
                         else{
                             Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
@@ -549,11 +532,9 @@ class CreateUpdatePostFragment : Fragment() {
         binding.hashtagInputEditText.setText(createUpdatePostViewModel.hashtagEditText)
 
         if(binding.hashtagInputEditText.text.toString() == "") {
-            // show message(hashtag empty)
             Toast.makeText(context, context?.getText(R.string.hashtag_empty_message), Toast.LENGTH_LONG).show()
         }
         else if(createUpdatePostViewModel.hashtagList.size == 5) {
-            // show message(hashtag usage full)
             Toast.makeText(context, context?.getText(R.string.hashtag_usage_full_message), Toast.LENGTH_LONG).show()
         }
         else {
@@ -568,7 +549,6 @@ class CreateUpdatePostFragment : Fragment() {
             // reset hashtag EditText
             binding.hashtagInputEditText.setText("")
 
-            // update hashtag usage
             updateHashtagUsage()
         }
     }
@@ -584,7 +564,6 @@ class CreateUpdatePostFragment : Fragment() {
 
         // 위치 정보 사용에 동의했지만, 권한이 없는 경우
         if(latAndLong[0] == (-1.0).toBigDecimal()){
-            // 권한 요청
             Permission.requestNotGrantedPermissions(requireContext(), Permission.requiredPermissionsForLocation)
 
             // 권한 요청이 비동기적이기 때문에, 권한 요청 이후에 CreatePost 버튼을 다시 눌러야한다.
@@ -616,8 +595,7 @@ class CreateUpdatePostFragment : Fragment() {
                     val intent = Intent()
                     intent.putExtra("postId", response.body()!!.id)
                     requireActivity().setResult(Activity.RESULT_OK, intent)
-                    
-                    // get created post id + update post media
+
                     getIdAndUpdateMedia()
                 }
                 else {
@@ -652,7 +630,6 @@ class CreateUpdatePostFragment : Fragment() {
 
         // 위치 정보 사용에 동의했지만, 권한이 없는 경우
         if(latAndLong[0] == (-1.0).toBigDecimal()){
-            // 권한 요청
             Permission.requestNotGrantedPermissions(requireContext(), Permission.requiredPermissionsForLocation)
 
             // 권한 요청이 비동기적이기 때문에, 권한 요청 이후에 CreatePost 버튼을 다시 눌러야한다.
@@ -777,10 +754,7 @@ class CreateUpdatePostFragment : Fragment() {
                     if(isViewDestroyed) return
 
                     if(response.isSuccessful) {
-                        // Pass post id, position to Community
                         passDataToCommunity()
-
-                        // close after success
                         closeAfterSuccess()
                     }
                     else {
@@ -822,8 +796,6 @@ class CreateUpdatePostFragment : Fragment() {
 
                 if(response.isSuccessful) {
                     val postId = (response.body()?.postList?.get(0) as Post).id
-
-                    // update post media
                     updatePostMedia(postId)
                 }
                 else {
@@ -905,7 +877,6 @@ class CreateUpdatePostFragment : Fragment() {
                 }
 
                 override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                    // if the view was destroyed(API call canceled) -> return
                     if(isViewDestroyed) return
 
                     Util.showToastAndLog(requireContext(), t.message.toString())

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -203,6 +203,10 @@ class CreateUpdatePostFragment : Fragment() {
         }
 
         // for hashtag EditText listener
+        binding.hashtagInputEditText.setOnEditorActionListener{ _, _, _ ->
+            addHashtag()
+            true
+        }
         binding.hashtagInputEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 createUpdatePostViewModel.hashtagEditText = s.toString()
@@ -213,33 +217,7 @@ class CreateUpdatePostFragment : Fragment() {
 
         // for hashtag input button
         binding.hashtagInputButton.setOnClickListener {
-            // trim hashtag
-            createUpdatePostViewModel.hashtagEditText = createUpdatePostViewModel.hashtagEditText.trim()
-            binding.hashtagInputEditText.setText(createUpdatePostViewModel.hashtagEditText)
-
-            if(binding.hashtagInputEditText.text.toString() == "") {
-                // show message(hashtag empty)
-                Toast.makeText(context, context?.getText(R.string.hashtag_empty_message), Toast.LENGTH_LONG).show()
-            }
-            else if(createUpdatePostViewModel.hashtagList.size == 5) {
-                // show message(hashtag usage full)
-                Toast.makeText(context, context?.getText(R.string.hashtag_usage_full_message), Toast.LENGTH_LONG).show()
-            }
-            else {
-                // save hashtag
-                val hashtag = binding.hashtagInputEditText.text.toString()
-                createUpdatePostViewModel.hashtagList.add(hashtag)
-
-                // update RecyclerView
-                hashtagAdapter.notifyItemInserted(createUpdatePostViewModel.hashtagList.size)
-                binding.hashtagRecyclerView.smoothScrollToPosition(createUpdatePostViewModel.hashtagList.size - 1)
-
-                // reset hashtag EditText
-                binding.hashtagInputEditText.setText("")
-
-                // update hashtag usage
-                updateHashtagUsage()
-            }
+            addHashtag()
         }
 
         // for post EditText listener
@@ -572,6 +550,35 @@ class CreateUpdatePostFragment : Fragment() {
     private fun setButtonToNormal() {
         binding.confirmButton.visibility = View.VISIBLE
         binding.createUpdatePostProgressBar.visibility = View.GONE
+    }
+
+    private fun addHashtag(){
+        createUpdatePostViewModel.hashtagEditText = createUpdatePostViewModel.hashtagEditText.trim()
+        binding.hashtagInputEditText.setText(createUpdatePostViewModel.hashtagEditText)
+
+        if(binding.hashtagInputEditText.text.toString() == "") {
+            // show message(hashtag empty)
+            Toast.makeText(context, context?.getText(R.string.hashtag_empty_message), Toast.LENGTH_LONG).show()
+        }
+        else if(createUpdatePostViewModel.hashtagList.size == 5) {
+            // show message(hashtag usage full)
+            Toast.makeText(context, context?.getText(R.string.hashtag_usage_full_message), Toast.LENGTH_LONG).show()
+        }
+        else {
+            // save hashtag
+            val hashtag = binding.hashtagInputEditText.text.toString()
+            createUpdatePostViewModel.hashtagList.add(hashtag)
+
+            // update RecyclerView
+            hashtagAdapter.notifyItemInserted(createUpdatePostViewModel.hashtagList.size)
+            binding.hashtagRecyclerView.smoothScrollToPosition(createUpdatePostViewModel.hashtagList.size - 1)
+
+            // reset hashtag EditText
+            binding.hashtagInputEditText.setText("")
+
+            // update hashtag usage
+            updateHashtagUsage()
+        }
     }
 
     // create post

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -85,6 +85,8 @@ class CreateUpdatePostFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentCreateUpdatePostBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val root: View = binding.root
 
         // initialize RecyclerView(photos and videos)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/CreateUpdatePostFragment.kt
@@ -362,21 +362,14 @@ class CreateUpdatePostFragment : Fragment() {
                     setPetSpinner()
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchPetResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -412,8 +405,7 @@ class CreateUpdatePostFragment : Fragment() {
                         }
                         // else -> show(Toast)/log error message
                         else{
-                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                            Log.d("error", errorMessage)
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
                 }
@@ -421,9 +413,7 @@ class CreateUpdatePostFragment : Fragment() {
                 override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                     if(isViewDestroyed) return
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
     }
@@ -635,12 +625,7 @@ class CreateUpdatePostFragment : Fragment() {
                     createUpdatePostViewModel.apiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -651,9 +636,7 @@ class CreateUpdatePostFragment : Fragment() {
                 createUpdatePostViewModel.apiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -716,12 +699,7 @@ class CreateUpdatePostFragment : Fragment() {
                     createUpdatePostViewModel.apiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -732,9 +710,7 @@ class CreateUpdatePostFragment : Fragment() {
                 createUpdatePostViewModel.apiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -757,12 +733,7 @@ class CreateUpdatePostFragment : Fragment() {
                     createUpdatePostViewModel.apiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -773,9 +744,7 @@ class CreateUpdatePostFragment : Fragment() {
                 createUpdatePostViewModel.apiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -819,12 +788,7 @@ class CreateUpdatePostFragment : Fragment() {
                         createUpdatePostViewModel.apiIsLoading = false
                         setButtonToNormal()
 
-                        // get error message + show(Toast)
-                        val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                        // log error message
-                        Log.d("error", errorMessage)
+                        Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                     }
                 }
 
@@ -835,9 +799,7 @@ class CreateUpdatePostFragment : Fragment() {
                     createUpdatePostViewModel.apiIsLoading = false
                     setButtonToNormal()
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
         }
@@ -869,12 +831,7 @@ class CreateUpdatePostFragment : Fragment() {
                     createUpdatePostViewModel.apiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -885,9 +842,7 @@ class CreateUpdatePostFragment : Fragment() {
                 createUpdatePostViewModel.apiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -945,12 +900,7 @@ class CreateUpdatePostFragment : Fragment() {
                         }
                     }
                     else {
-                        // get error message
-                        val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                        // Toast + Log
-                        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                        Log.d("error", errorMessage)
+                        Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                     }
                 }
 
@@ -958,9 +908,7 @@ class CreateUpdatePostFragment : Fragment() {
                     // if the view was destroyed(API call canceled) -> return
                     if(isViewDestroyed) return
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
         }
@@ -1020,27 +968,18 @@ class CreateUpdatePostFragment : Fragment() {
                     }
                 }
                 else {
-                    // close activity
                     requireActivity().finish()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchPostResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // close activity
                 requireActivity().finish()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/HashtagListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/createUpdatePost/HashtagListAdapter.kt
@@ -46,7 +46,6 @@ class HashtagListAdapter(private val createUpdatePostViewModel: CreateUpdatePost
     override fun getItemCount() = resultList.size
 
     private fun deleteItem(position: Int) {
-        // delete ViewModel RecyclerView list values
         createUpdatePostViewModel.hashtagList.removeAt(position)
 
         // for item remove animation

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
@@ -118,18 +118,12 @@ class FollowerAdapter(val context: Context) :
                     // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(context, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<CreateFollowResDto>, t: Throwable) {
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(context, t.message.toString())
             }
         })
     }
@@ -162,12 +156,7 @@ class FollowerAdapter(val context: Context) :
                     // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(context, response.errorBody())
                 }
             }
 
@@ -175,8 +164,7 @@ class FollowerAdapter(val context: Context) :
                 // set button to normal
                 holder.followUnfollowButton.isEnabled = true
 
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(context, t.message.toString())
             }
         })
     }
@@ -206,18 +194,12 @@ class FollowerAdapter(val context: Context) :
                     )
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(context, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(context, t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
@@ -111,11 +111,9 @@ class FollowerAdapter(val context: Context) :
                     )
                     notifyItemChanged(position)
 
-                    // set button to normal
                     holder.followUnfollowButton.isEnabled = true
                 }
                 else {
-                    // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
                     Util.showToastAndLogForFailedResponse(context, response.errorBody())
@@ -149,11 +147,9 @@ class FollowerAdapter(val context: Context) :
                     )
                     notifyItemChanged(position)
 
-                    // set button to normal
                     holder.followUnfollowButton.isEnabled = true
                 }
                 else {
-                    // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
                     Util.showToastAndLogForFailedResponse(context, response.errorBody())
@@ -161,7 +157,6 @@ class FollowerAdapter(val context: Context) :
             }
 
             override fun onFailure(call: Call<DeleteFollowResDto>, t: Throwable) {
-                // set button to normal
                 holder.followUnfollowButton.isEnabled = true
 
                 Util.showToastAndLog(context, t.message.toString())

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingActivity.kt
@@ -19,7 +19,6 @@ class FollowerFollowingActivity : AppCompatActivity() {
         binding = ActivityFollowerFollowingBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // hide action bar
         supportActionBar?.hide()
 
         // open fragment

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
@@ -45,6 +45,8 @@ class FollowerFollowingFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentFollowerFollowingBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+        
         return binding.root
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
@@ -151,21 +151,14 @@ class FollowerFollowingFragment : Fragment() {
                     followerFollowingViewModel.setFollowerTitle(followerText)
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchFollowingResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(requireContext(), t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -193,21 +186,14 @@ class FollowerFollowingFragment : Fragment() {
                     followerFollowingViewModel.setFollowingTitle(followingText)
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchFollowerResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(requireContext(), t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
@@ -78,7 +78,6 @@ class FollowerFragment : Fragment() {
     override fun onResume() {
         super.onResume()
 
-        // update RecyclerView
         updateRecyclerView()
     }
 
@@ -104,7 +103,6 @@ class FollowerFragment : Fragment() {
                         followingIdList.add(it.id)
                     }
 
-                    // fetch follower
                     fetchFollower()
                 }
                 else {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
@@ -108,21 +108,14 @@ class FollowerFragment : Fragment() {
                     fetchFollower()
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchFollowerResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(requireContext(), t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -171,12 +164,7 @@ class FollowerFragment : Fragment() {
                     // set swipe isRefreshing to false
                     binding.followerSwipeRefreshLayout.isRefreshing = false
 
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -186,9 +174,7 @@ class FollowerFragment : Fragment() {
                 // set swipe isRefreshing to false
                 binding.followerSwipeRefreshLayout.isRefreshing = false
 
-                // show(Toast)/log error message
-                Toast.makeText(requireContext(), t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
@@ -47,6 +47,8 @@ class FollowerFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentFollowerBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val root = binding.root
 
         // initialize RecyclerView

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
@@ -129,12 +129,7 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
                     // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(context, response.errorBody())
                 }
             }
 
@@ -144,8 +139,7 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
                 // set button to normal
                 holder.followUnfollowButton.isEnabled = true
 
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(context, t.message.toString())
             }
         })
     }
@@ -175,18 +169,12 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
                     )
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(context, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(context, t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
@@ -110,7 +110,6 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful) {
-                    // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
                     // remove from list
@@ -126,7 +125,6 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
                     notifyItemRangeChanged(position, resultList.size)
                 }
                 else {
-                    // set button to normal
                     holder.followUnfollowButton.isEnabled = true
 
                     Util.showToastAndLogForFailedResponse(context, response.errorBody())
@@ -136,7 +134,6 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
             override fun onFailure(call: Call<DeleteFollowResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // set button to normal
                 holder.followUnfollowButton.isEnabled = true
 
                 Util.showToastAndLog(context, t.message.toString())

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
@@ -122,12 +122,7 @@ class FollowingFragment : Fragment() {
                     // set swipe isRefreshing to false
                     binding.followingSwipeRefreshLayout.isRefreshing = false
 
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -137,9 +132,7 @@ class FollowingFragment : Fragment() {
                 // set swipe isRefreshing to false
                 binding.followingSwipeRefreshLayout.isRefreshing = false
 
-                // show(Toast)/log error message
-                Toast.makeText(requireContext(), t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
@@ -45,6 +45,8 @@ class FollowingFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentFollowingBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val root = binding.root
 
         // for swipe refresh

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
@@ -102,7 +102,6 @@ class SearchActivity : AppCompatActivity() {
             updateFollowerIdList()
         }
 
-        // restore views
         restoreState()
     }
 
@@ -153,7 +152,6 @@ class SearchActivity : AppCompatActivity() {
         val nicknameText = searchViewModel.accountNickname + '님'
         binding.accountNickname.text = nicknameText
 
-        // set button status
         setButtonState()
     }
 
@@ -248,7 +246,6 @@ class SearchActivity : AppCompatActivity() {
                 setSearchButtonToNormal()
 
                 if(response.isSuccessful) {
-                    // set account info views
                     setAccountInfoViews(response.body()!!)
                 }
                 else {
@@ -297,13 +294,9 @@ class SearchActivity : AppCompatActivity() {
                     // save photo as byte array
                     searchViewModel.accountPhotoByteArray = response.body()!!.byteStream().readBytes()
 
-                    // set account photo
                     setAccountPhoto()
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
                     Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }
             }
@@ -331,19 +324,14 @@ class SearchActivity : AppCompatActivity() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful) {
-                    // update follower id list(update button state)
                     updateFollowerIdList()
 
-                    // set api state/button to normal
                     searchViewModel.apiIsLoading = false
                 }
                 else {
                     // set api state/button to normal
                     searchViewModel.apiIsLoading = false
                     setButtonState()
-
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
 
                     Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }
@@ -372,19 +360,14 @@ class SearchActivity : AppCompatActivity() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful) {
-                    // update follower id list(update button state)
                     updateFollowerIdList()
 
-                    // set api state/button to normal
                     searchViewModel.apiIsLoading = false
                 }
                 else {
                     // set api state/button to normal
                     searchViewModel.apiIsLoading = false
                     setButtonState()
-
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
 
                     Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
@@ -52,7 +52,11 @@ class SearchActivity : AppCompatActivity() {
         binding = ActivitySearchBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // for search EditText listener
+        // searchEditText listener
+        binding.searchEditText.setOnEditorActionListener{ _, _, _ ->
+            checkPatternUsernameAndSearchAccount()
+            true
+        }
         binding.searchEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 searchViewModel.searchEditText = s.toString()
@@ -63,17 +67,7 @@ class SearchActivity : AppCompatActivity() {
 
         // for search button
         binding.searchButton.setOnClickListener {
-            // verify regex + show message if invalid
-            if(!patternUsername.matcher(searchViewModel.searchEditText).matches()) {
-                Toast.makeText(this, getString(R.string.nickname_regex_exception_message), Toast.LENGTH_LONG).show()
-            }
-            else {
-                // set api state/button to loading
-                searchViewModel.apiIsLoading = true
-                setSearchButtonToLoading()
-
-                searchAccount(searchViewModel.searchEditText)
-            }
+            checkPatternUsernameAndSearchAccount()
         }
 
         // for follow unfollow button
@@ -108,6 +102,19 @@ class SearchActivity : AppCompatActivity() {
 
         // restore views
         restoreState()
+    }
+
+    private fun checkPatternUsernameAndSearchAccount(){
+        if(!patternUsername.matcher(searchViewModel.searchEditText).matches()) {
+            Toast.makeText(this, getString(R.string.nickname_regex_exception_message), Toast.LENGTH_LONG).show()
+        }
+        else {
+            // set api state/button to loading
+            searchViewModel.apiIsLoading = true
+            setSearchButtonToLoading()
+
+            searchAccount(searchViewModel.searchEditText)
+        }
     }
 
     private fun setSearchButtonToLoading() {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
@@ -50,6 +50,8 @@ class SearchActivity : AppCompatActivity() {
 
         // view binding
         binding = ActivitySearchBinding.inflate(layoutInflater)
+        isViewDestroyed = false
+
         setContentView(binding.root)
 
         // searchEditText listener

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
@@ -217,21 +217,14 @@ class SearchActivity : AppCompatActivity() {
                     setButtonState()
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // Toast + Log
-                    Toast.makeText(this@SearchActivity, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchFollowerResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(this@SearchActivity, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(this@SearchActivity, t.message.toString())
             }
         })
     }
@@ -263,18 +256,15 @@ class SearchActivity : AppCompatActivity() {
                     when(val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)) {
                         // if no such account exists -> show Toast message
                         "Account not exists" -> {
-                            Toast.makeText(this@SearchActivity,
-                                getText(R.string.account_does_not_exist_exception_message), Toast.LENGTH_LONG).show()
+                            Util.showToastAndLog(this@SearchActivity, getString(R.string.account_does_not_exist_exception_message))
                         }
                         // if fetched self -> show Toast message
                         "Fetched self" -> {
-                            Toast.makeText(this@SearchActivity,
-                                getText(R.string.fetched_self_exception_message), Toast.LENGTH_LONG).show()
+                            Util.showToastAndLog(this@SearchActivity, getString(R.string.fetched_self_exception_message))
                         }
                         // other exceptions -> show Toast message + log
                         else -> {
-                            Toast.makeText(this@SearchActivity, errorMessage, Toast.LENGTH_LONG).show()
-                            Log.d("error", errorMessage)
+                            Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                         }
                     }
                 }
@@ -287,9 +277,7 @@ class SearchActivity : AppCompatActivity() {
                 searchViewModel.apiIsLoading = false
                 setSearchButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(this@SearchActivity, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(this@SearchActivity, t.message.toString())
             }
         })
     }
@@ -316,18 +304,14 @@ class SearchActivity : AppCompatActivity() {
                     // get error message
                     val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
 
-                    // Toast + Log
-                    Toast.makeText(this@SearchActivity, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(this@SearchActivity, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(this@SearchActivity, t.message.toString())
             }
         })
     }
@@ -361,18 +345,14 @@ class SearchActivity : AppCompatActivity() {
                     // get error message
                     val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
 
-                    // Toast + Log
-                    Toast.makeText(this@SearchActivity, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<CreateFollowResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(this@SearchActivity, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(this@SearchActivity, t.message.toString())
             }
         })
     }
@@ -406,18 +386,14 @@ class SearchActivity : AppCompatActivity() {
                     // get error message
                     val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
 
-                    // Toast + Log
-                    Toast.makeText(this@SearchActivity, errorMessage, Toast.LENGTH_LONG).show()
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(this@SearchActivity, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<DeleteFollowResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(this@SearchActivity, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(this@SearchActivity, t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginActivity.kt
@@ -26,7 +26,6 @@ class LoginActivity : AppCompatActivity() {
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // hide action bar
         supportActionBar?.hide()
 
         // show login fragment

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -136,7 +136,6 @@ class LoginFragment : Fragment() {
                 .commit()
         }
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentLoginParentLayout)
     }
 
@@ -171,10 +170,8 @@ class LoginFragment : Fragment() {
                 // create custom snack bar to display error message
                 displayErrorMessage(t.message.toString())
 
-                // enable buttons
                 enableButtons()
 
-                // log error message
                 Log.d("error", t.message.toString())
             }
         })
@@ -225,7 +222,8 @@ class LoginFragment : Fragment() {
 
                             startActivity(intent)
                             activity?.finish()
-                        } // 첫 로그인이 아닐 시
+                        }
+                        // 첫 로그인이 아닐 시
                         else{
                             // start main activity + send token
                             val intent = Intent(context, MainActivity::class.java)
@@ -247,10 +245,8 @@ class LoginFragment : Fragment() {
             override fun onFailure(call: Call<FetchAccountResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // enable buttons
                 enableButtons()
 
-                // log error message
                 Log.d("error", t.message.toString())
 
                 // create custom snack bar to display error message
@@ -259,7 +255,6 @@ class LoginFragment : Fragment() {
         })
     }
 
-    // disable buttons
     private fun disableButtons() {
         // set login button status to loading
         binding.loginButton.text = ""
@@ -271,7 +266,6 @@ class LoginFragment : Fragment() {
         binding.recoveryButton.isEnabled = false
     }
 
-    // enable buttons
     private fun enableButtons() {
         // set login button status to active
         binding.loginButton.text = context?.getText(R.string.login_button)
@@ -283,7 +277,6 @@ class LoginFragment : Fragment() {
         binding.recoveryButton.isEnabled = true
     }
 
-    // display error message(Snackbar)
     private fun displayErrorMessage(message: String) {
         snackBar = Snackbar.make(view?.findViewById(R.id.fragment_login_parent_layout)!!,
             message, Snackbar.LENGTH_LONG)
@@ -293,7 +286,6 @@ class LoginFragment : Fragment() {
         snackBar!!.show()
     }
 
-    // display success message(Snackbar)
     private fun displaySuccessMessage(message: String) {
         snackBar = Snackbar.make(view?.findViewById(R.id.fragment_login_parent_layout)!!,
             message, Snackbar.LENGTH_LONG)
@@ -309,7 +301,6 @@ class LoginFragment : Fragment() {
 
         isViewDestroyed = true
 
-        // dismiss Snackbar
         snackBar?.dismiss()
     }
 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -92,6 +92,14 @@ class LoginFragment : Fragment() {
         })
 
         // for pw text change listener
+        binding.pwEditText.setOnEditorActionListener { _, _, _ ->
+            Util.hideKeyboard(requireActivity())
+
+            disableButtons()
+            login(binding.usernameEditText.text.toString(), binding.pwEditText.text.toString())
+
+            true
+        }
         binding.pwEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 loginViewModel.loginPwEditText = s.toString()
@@ -102,10 +110,7 @@ class LoginFragment : Fragment() {
 
         // for login button
         binding.loginButton.setOnClickListener {
-            // disable buttons
             disableButtons()
-
-            // call login function
             login(binding.usernameEditText.text.toString(), binding.pwEditText.text.toString())
         }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -91,7 +91,7 @@ class LoginFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for pw text change listener
+        // pwEditText Listener
         binding.pwEditText.setOnEditorActionListener { _, _, _ ->
             Util.hideKeyboard(requireActivity())
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -66,6 +66,8 @@ class LoginFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentLoginBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         return binding.root
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountCredentialsFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountCredentialsFragment.kt
@@ -39,7 +39,6 @@ class CreateAccountCredentialsFragment : Fragment() {
         // variable for ViewModel
         val loginViewModel: LoginViewModel by activityViewModels()
 
-        // for state restore(ViewModel)
         restoreState(loginViewModel)
 
         // for username text change listener
@@ -110,7 +109,6 @@ class CreateAccountCredentialsFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentCreateAccountCredentialsParentLayout)
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountCredentialsFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountCredentialsFragment.kt
@@ -88,7 +88,11 @@ class CreateAccountCredentialsFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for pw check text change listener
+        // pwCheckEditText Listener
+        binding.pwCheckEditText.setOnEditorActionListener { _, _, _ ->
+            Util.hideKeyboard(requireActivity())
+            true
+        }
         binding.pwCheckEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 if(s.toString() == binding.pwEditText.text.toString()) {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountFragment.kt
@@ -74,6 +74,8 @@ class CreateAccountFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentCreateAccountBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         return binding.root
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountFragment.kt
@@ -276,17 +276,13 @@ class CreateAccountFragment : Fragment() {
             override fun onFailure(call: Call<CreateAccountResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // log error message
-                Log.d("error", t.message.toString())
-
                 // set next button to normal
                 setNextButtonToNormal()
 
                 // reset createAccountApiCall variable
                 createAccountApiCall = null
 
-                //display error toast message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -317,12 +313,10 @@ class CreateAccountFragment : Fragment() {
                         createAccount(loginViewModel)
                     }
                     else {
-                        // code invalid Toast message
-                        Toast.makeText(context, context?.getText(R.string.email_message_code_invalid),
-                            Toast.LENGTH_LONG).show()
-
                         // set next button to normal
                         setNextButtonToNormal()
+
+                        Util.showToastAndLog(requireContext(), requireContext().getString(R.string.email_message_code_invalid))
                     }
 
                     // reset verifyAuthCodeApiCall variable
@@ -332,17 +326,13 @@ class CreateAccountFragment : Fragment() {
                 override fun onFailure(call: Call<VerifyAuthCodeResDto>, t: Throwable) {
                     if(isViewDestroyed) return
 
-                    // log error message
-                    Log.d("error", t.message.toString())
-
                     // set next button to normal
                     setNextButtonToNormal()
 
                     // reset verifyAuthCodeApiCall variable
                     verifyAuthCodeApiCall = null
 
-                    //display error toast message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
         }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountFragment.kt
@@ -109,7 +109,7 @@ class CreateAccountFragment : Fragment() {
             childFragmentManager.popBackStack()
         }
 
-        //for next step button
+        // for next step button
         binding.nextStepButton.setOnClickListener {
             var nextFragment: Fragment? = null
             var nextFragmentTag: String? = null
@@ -150,23 +150,19 @@ class CreateAccountFragment : Fragment() {
             }
         }
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentCreateAccountParentLayout)
     }
 
-    // show previous step button
     public fun showPreviousButton() {
         if(createAccountApiCall == null && verifyAuthCodeApiCall == null) {
             binding.previousStepButton.visibility = View.VISIBLE
         }
     }
 
-    // hide previous step button
     public fun hidePreviousButton() {
         binding.previousStepButton.visibility = View.INVISIBLE
     }
 
-    // enable next step button
     public fun enableNextButton() {
         if(createAccountApiCall == null && verifyAuthCodeApiCall == null) {
             binding.nextStepButton.isEnabled = true
@@ -180,7 +176,6 @@ class CreateAccountFragment : Fragment() {
         }
     }
 
-    // disable next step button
     public fun disableNextButton() {
         binding.nextStepButton.isEnabled = false
 
@@ -192,7 +187,6 @@ class CreateAccountFragment : Fragment() {
         }
     }
 
-    // set next step button to normal
     private fun setNextButtonToNormal() {
         // set create account button status to normal + enable
         binding.nextStepButton.text = context?.getText(R.string.create_account_button)
@@ -203,7 +197,6 @@ class CreateAccountFragment : Fragment() {
         binding.previousStepButton.visibility = View.VISIBLE
     }
 
-    // set next step button to loading
     private fun setNextButtonToLoading() {
         // set create account button status to loading + disable
         binding.nextStepButton.text = ""
@@ -276,7 +269,6 @@ class CreateAccountFragment : Fragment() {
             override fun onFailure(call: Call<CreateAccountResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // set next button to normal
                 setNextButtonToNormal()
 
                 // reset createAccountApiCall variable
@@ -313,7 +305,6 @@ class CreateAccountFragment : Fragment() {
                         createAccount(loginViewModel)
                     }
                     else {
-                        // set next button to normal
                         setNextButtonToNormal()
 
                         Util.showToastAndLog(requireContext(), requireContext().getString(R.string.email_message_code_invalid))
@@ -326,7 +317,6 @@ class CreateAccountFragment : Fragment() {
                 override fun onFailure(call: Call<VerifyAuthCodeResDto>, t: Throwable) {
                     if(isViewDestroyed) return
 
-                    // set next button to normal
                     setNextButtonToNormal()
 
                     // reset verifyAuthCodeApiCall variable

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
@@ -81,7 +81,11 @@ class CreateAccountUserInfoFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for email text change listener
+        // emailEditText Listener
+        binding.emailEditText.setOnEditorActionListener { _, _, _ ->
+            Util.hideKeyboard(requireActivity())
+            true
+        }
         binding.emailEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 if(patternEmail.matcher(s).matches()) {
@@ -103,7 +107,11 @@ class CreateAccountUserInfoFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for email code text change listener
+        // emailCodeEditText Listener
+        binding.emailCodeEditText.setOnEditorActionListener { _, _, _ ->
+            Util.hideKeyboard(requireActivity())
+            true
+        }
         binding.emailCodeEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 loginViewModel.createAccountEmailCodeEditText = s.toString()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
@@ -2,6 +2,7 @@ package com.sju18001.petmanagement.ui.login.createAccount
 
 import android.os.Bundle
 import android.os.SystemClock
+import android.telephony.PhoneNumberFormattingTextWatcher
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
@@ -60,6 +61,7 @@ class CreateAccountUserInfoFragment : Fragment() {
         restoreState(loginViewModel)
 
         // for phone text change listener
+        binding.phoneEditText.addTextChangedListener(PhoneNumberFormattingTextWatcher("KR"))
         binding.phoneEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 if(patternPhone.matcher(s).matches()) {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
@@ -238,14 +238,7 @@ class CreateAccountUserInfoFragment : Fragment() {
                     startTimer(loginViewModel)
                 }
                 else {
-                    // get error message
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    //display error toast message
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
 
                 // set request code button to normal
@@ -258,17 +251,13 @@ class CreateAccountUserInfoFragment : Fragment() {
             override fun onFailure(call: Call<SendAuthCodeResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // log error message
-                Log.d("error", t.message.toString())
-
                 // set request code button to normal
                 setRequestCodeButtonToNormal()
 
                 // reset codeRequestApiCall variable
                 codeRequestApiCall = null
 
-                //display error toast message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
@@ -142,7 +142,6 @@ class CreateAccountUserInfoFragment : Fragment() {
         binding.requestEmailCodeProgressBar.visibility = View.GONE
         binding.requestEmailCodeButton.isEnabled = true
 
-        // enable email edit text
         binding.emailEditText.isEnabled = true
     }
 
@@ -153,7 +152,6 @@ class CreateAccountUserInfoFragment : Fragment() {
         binding.requestEmailCodeProgressBar.visibility = View.VISIBLE
         binding.requestEmailCodeButton.isEnabled = false
 
-        // disable email edit text
         binding.emailEditText.isEnabled = false
     }
 
@@ -251,7 +249,6 @@ class CreateAccountUserInfoFragment : Fragment() {
             override fun onFailure(call: Call<SendAuthCodeResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // set request code button to normal
                 setRequestCodeButtonToNormal()
 
                 // reset codeRequestApiCall variable

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/createAccount/CreateAccountUserInfoFragment.kt
@@ -48,6 +48,8 @@ class CreateAccountUserInfoFragment : Fragment() {
     ): View? {
         // view binding
         _binding = FragmentCreateAccountUserInfoBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         return binding.root
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
@@ -199,7 +199,7 @@ class RecoverPasswordFragment : Fragment() {
                     setViewForCodeInput()
                 }else{
                     // 어떤 이메일이든 코드 전송은 하기 때문에, 보통 실패할 수 없다.
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_LONG).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -209,7 +209,7 @@ class RecoverPasswordFragment : Fragment() {
                 // 버튼 로딩 상태 해제
                 setEmailInputButtonLoading(false)
 
-                Toast.makeText(context, "Error: ${t.message}", Toast.LENGTH_LONG).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -254,7 +254,8 @@ class RecoverPasswordFragment : Fragment() {
                     setViewForResult()
                 } else {
                     binding.codeMessage.visibility = View.VISIBLE
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_LONG).show()
+
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -264,7 +265,7 @@ class RecoverPasswordFragment : Fragment() {
                 // 버튼 로딩 상태 해제
                 setCodeInputButtonLoading(false)
 
-                Toast.makeText(context, "Error: ${t.message}", Toast.LENGTH_LONG).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
@@ -26,7 +26,7 @@ class RecoverPasswordFragment : Fragment() {
     // 정규식
     private val patternUsername: Pattern = Pattern.compile("^[a-z0-9]{5,16}$")
 
-    private var isViewDestroyed: Boolean = false
+    private var isViewDestroyed = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -34,6 +34,7 @@ class RecoverPasswordFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentRecoverPasswordBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         when(savedInstanceState?.getInt("page")){
             1 -> setViewForCodeInput()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
@@ -42,7 +42,6 @@ class RecoverPasswordFragment : Fragment() {
             else -> setViewForEmailInput()
         }
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentRecoverPasswordParentLayout)
 
         return binding.root
@@ -195,7 +194,6 @@ class RecoverPasswordFragment : Fragment() {
                 setEmailInputButtonLoading(false)
 
                 if(response.isSuccessful){
-                    // 코드 입력
                     setViewForCodeInput()
                 }else{
                     // 어떤 이메일이든 코드 전송은 하기 때문에, 보통 실패할 수 없다.
@@ -206,7 +204,6 @@ class RecoverPasswordFragment : Fragment() {
             override fun onFailure(call: Call<SendAuthCodeResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // 버튼 로딩 상태 해제
                 setEmailInputButtonLoading(false)
 
                 Util.showToastAndLog(requireContext(), t.message.toString())
@@ -214,7 +211,6 @@ class RecoverPasswordFragment : Fragment() {
         })
     }
 
-    // 이메일 입력 버튼 프로그래스바
     private fun setEmailInputButtonLoading(isLoading: Boolean){
         if(isLoading){
             binding.emailInputButton.apply {
@@ -232,11 +228,9 @@ class RecoverPasswordFragment : Fragment() {
     }
 
 
-    // 코드를 통한 비밀번호 임시 변경
     private fun recoverPassword(username: String, code: String){
         val recoverPasswordReqDto = RecoverPasswordReqDto(username, code)
 
-        // 버튼 로딩 상태
         setCodeInputButtonLoading(true)
 
         val call = RetrofitBuilder.getServerApi().recoverPasswordReq(recoverPasswordReqDto)
@@ -247,7 +241,6 @@ class RecoverPasswordFragment : Fragment() {
             ) {
                 if(isViewDestroyed) return
 
-                // 버튼 로딩 상태 해제
                 setCodeInputButtonLoading(false)
 
                 if (response.isSuccessful) {
@@ -262,7 +255,6 @@ class RecoverPasswordFragment : Fragment() {
             override fun onFailure(call: Call<RecoverPasswordResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // 버튼 로딩 상태 해제
                 setCodeInputButtonLoading(false)
 
                 Util.showToastAndLog(requireContext(), t.message.toString())
@@ -270,7 +262,6 @@ class RecoverPasswordFragment : Fragment() {
         })
     }
 
-    // 코드 입력 버튼 프로그래스바
     private fun setCodeInputButtonLoading(isLoading: Boolean){
         if(isLoading){
             binding.codeInputButton.apply {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
@@ -102,6 +102,14 @@ class RecoverPasswordFragment : Fragment() {
         setMessageGone()
 
         // 이메일 입력란 입력
+        binding.emailEditText.setOnEditorActionListener{ _, _, _ ->
+            if(binding.emailInputButton.isEnabled){
+                Util.hideKeyboard(requireActivity())
+                sendAuthCode(binding.emailEditText.text.toString())
+            }
+
+            true
+        }
         binding.emailEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 checkEmailValidation(s)
@@ -112,7 +120,6 @@ class RecoverPasswordFragment : Fragment() {
 
         // 버튼 클릭
         binding.emailInputButton.setOnClickListener{
-            // 인증코드 전송
             sendAuthCode(binding.emailEditText.text.toString())
         }
     }
@@ -137,9 +144,18 @@ class RecoverPasswordFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
+        // 인증 코드 입력
+        binding.codeEditText.setOnEditorActionListener{ _, _, _ ->
+            if(binding.codeInputButton.isEnabled){
+                Util.hideKeyboard(requireActivity())
+                recoverPassword(binding.usernameEditText.text.toString(), binding.codeEditText.text.toString())
+            }
+
+            true
+        }
+
         // 버튼 클릭
         binding.codeInputButton.setOnClickListener{
-            // 코드 확인
             recoverPassword(binding.usernameEditText.text.toString(), binding.codeEditText.text.toString())
         }
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
@@ -59,6 +59,14 @@ class RecoverUsernameFragment : Fragment() {
         }
 
         // 이메일 입력란 입력
+        binding.emailEditText.setOnEditorActionListener{ _, _, _ ->
+            if(binding.recoverUsernameButton.isEnabled){
+                Util.hideKeyboard(requireActivity())
+                recoverUsername(binding.emailEditText.text.toString())
+            }
+
+            true
+        }
         binding.emailEditText.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 checkEmailValidation(s)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
@@ -77,7 +77,6 @@ class RecoverUsernameFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentRecoveryUsernameParentLayout)
     }
 
@@ -130,7 +129,6 @@ class RecoverUsernameFragment : Fragment() {
     }
 
 
-    // 아이디 찾기
     private fun recoverUsername(email: String){
         val recoverUsernameReqDto = RecoverUsernameReqDto(email)
         val call = RetrofitBuilder.getServerApi().recoverUsernameReq(recoverUsernameReqDto)
@@ -184,7 +182,6 @@ class RecoverUsernameFragment : Fragment() {
         }
     }
 
-    // 아이디 찾기 결과
     private fun setViewForResult(username: String?){
         binding.resultUsername.text = username
         binding.recoverUsernameLayout.visibility = View.GONE

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
@@ -153,7 +153,7 @@ class RecoverUsernameFragment : Fragment() {
                         setViewForResult(it.username)
                     }
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_LONG).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -163,7 +163,7 @@ class RecoverUsernameFragment : Fragment() {
                 // 버튼 로딩 상태 해제
                 setButtonLoading(false)
 
-                Toast.makeText(context, getString(R.string.fail_request), Toast.LENGTH_SHORT).show()
+                Util.showToastAndLog(requireContext(), getString(R.string.fail_request))
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
@@ -35,6 +35,7 @@ class RecoverUsernameFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentRecoverUsernameBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         if(savedInstanceState?.getBoolean("is_result_shown") == true){
             val username = savedInstanceState.getString("result_username")

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
@@ -48,6 +48,8 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
     private var _binding: FragmentMapBinding? = null
     private val binding get() = _binding!!
 
+    private var isViewDestroyed = false
+
     // 지도 관련
     private var currentMapPoint: MapPoint? = null
     private var isLoadingCurrentMapPoint: Boolean = false
@@ -85,6 +87,8 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
             ViewModelProvider(this).get(MapViewModel::class.java)
 
         _binding = FragmentMapBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val root: View = binding.root
 
         navView = requireActivity().findViewById<BottomNavigationView>(R.id.nav_view)
@@ -180,6 +184,7 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        isViewDestroyed = true
     }
 
 
@@ -268,6 +273,8 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
                     call: Call<Documents>,
                     response: Response<Documents>
                 ) {
+                    if(isViewDestroyed) return
+
                     val body = response.body()
                     if(body != null){
                         currentDocuments = body.documents

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
@@ -283,7 +283,7 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
                 }
 
                 override fun onFailure(call: Call<Documents>, t: Throwable) {
-                    Log.i("MapFragment", "Failed To Get Request: ${t.message}")
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
 
             })

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
@@ -172,10 +172,8 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
         }
 
 
-        // 애니메이션 초기화
         initializeAnimations()
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentMapParentLayout)
 
         return root

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -176,20 +176,14 @@ class MyPageFragment : Fragment() {
                         binding.accountPhoto.setImageBitmap(BitmapFactory.decodeByteArray(myPageViewModel.accountPhotoProfileByteArray, 0, myPageViewModel.accountPhotoProfileByteArray!!.size))
                     }
                     else {
-                        // get error message + show(Toast)
-                        val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                        // log error message
-                        Log.d("error", errorMessage)
+                        Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                     }
                 }
 
                 override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                     if(isViewDestroyed) return
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -152,8 +152,8 @@ class MyPageFragment : Fragment() {
 
     // fetch account photo
     private fun fetchAccountPhotoAndSetView() {
-        // 사진이 없을 때, 기본 사진으로 셋팅
         if(accountData!!.photoUrl == null){
+            // 기본 사진으로 세팅
             binding.accountPhoto.setImageDrawable(requireActivity().getDrawable(R.drawable.ic_baseline_account_circle_36))
             return
         }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -46,6 +46,7 @@ class MyPageFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentMyPageBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         return binding.root
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -378,9 +378,7 @@ class EditAccountFragment : Fragment() {
                 }
 
                 override fun onFailure(call: Call<DeleteAccountPhotoResDto>, t: Throwable) {
-                    if(isViewDestroyed){
-                        return
-                    }
+                    if(isViewDestroyed) return
 
                     // show(Toast)/log error message
                     Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -71,6 +71,8 @@ class EditAccountFragment : Fragment() {
             ViewModelProvider(this).get(EditAccountViewModel::class.java)
 
         _binding = FragmentEditAccountBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val root: View = binding.root
 
         (activity as AppCompatActivity)!!.supportActionBar!!.hide()
@@ -355,9 +357,7 @@ class EditAccountFragment : Fragment() {
                     call: Call<DeleteAccountPhotoResDto>,
                     response: Response<DeleteAccountPhotoResDto>
                 ) {
-                    if(isViewDestroyed){
-                        return
-                    }
+                    if(isViewDestroyed) return
 
                     if(response.isSuccessful){
                         // 세션 갱신

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -325,21 +325,14 @@ class EditAccountFragment : Fragment() {
                     }
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<UpdateAccountResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -373,10 +366,7 @@ class EditAccountFragment : Fragment() {
                         if(errorMessage == "null"){
                             closeAfterSuccess()
                         }else{
-                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                            // log error message
-                            Log.d("error", errorMessage)
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
                 }
@@ -384,9 +374,7 @@ class EditAccountFragment : Fragment() {
                 override fun onFailure(call: Call<DeleteAccountPhotoResDto>, t: Throwable) {
                     if(isViewDestroyed) return
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
         }
@@ -414,21 +402,14 @@ class EditAccountFragment : Fragment() {
                         closeAfterSuccess()
                     }
                     else {
-                        // get error message + show(Toast)
-                        val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                        // log error message
-                        Log.d("error", errorMessage)
+                        Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                     }
                 }
 
                 override fun onFailure(call: Call<UpdateAccountPhotoResDto>, t: Throwable) {
                     if(isViewDestroyed) return
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
         }
@@ -453,21 +434,14 @@ class EditAccountFragment : Fragment() {
                     }
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, context?.getText(R.string.account_password_mismatch), Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLog(requireContext(), requireContext().getString(R.string.account_password_mismatch))
                 }
             }
 
             override fun onFailure(call: Call<UpdateAccountPasswordResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -509,21 +483,14 @@ class EditAccountFragment : Fragment() {
                     }
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<DeleteAccountResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -5,6 +5,7 @@ import android.app.Dialog
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.telephony.PhoneNumberFormattingTextWatcher
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
@@ -242,6 +243,7 @@ class EditAccountFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun afterTextChanged(s: Editable?) {}
         })
+        binding.phoneEdit.addTextChangedListener(PhoneNumberFormattingTextWatcher("KR"))
         binding.phoneEdit.addTextChangedListener(object: TextWatcher {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 myPageViewModel.accountPhoneValue = s.toString()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -86,7 +86,6 @@ class EditAccountFragment : Fragment() {
     override fun onStart() {
         super.onStart()
 
-        // for view restore
         restoreState()
 
         // for button listeners
@@ -191,7 +190,6 @@ class EditAccountFragment : Fragment() {
                 dialog.dismiss()
             }
 
-            // for hiding keyboard
             Util.setupViewsForHideKeyboard(requireActivity(), dialog.findViewById(R.id.password_change_parent_layout))
         }
 
@@ -261,7 +259,6 @@ class EditAccountFragment : Fragment() {
             override fun afterTextChanged(s: Editable?) {}
         })
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentEditAccountParentFragment)
     }
 
@@ -395,10 +392,8 @@ class EditAccountFragment : Fragment() {
                         account.photoUrl = response.body()!!.fileUrl
                         SessionManager.saveLoggedInAccount(requireContext(), account)
 
-                        // delete copied file
                         File(path).delete()
 
-                        // close after success
                         closeAfterSuccess()
                     }
                     else {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -365,15 +365,19 @@ class EditAccountFragment : Fragment() {
                         account.photoUrl = null
                         SessionManager.saveLoggedInAccount(requireContext(), account)
 
-                        // close after success
                         closeAfterSuccess()
                     }else{
-                        // get error message + show(Toast)
                         val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
 
-                        // log error message
-                        Log.d("error", errorMessage)
+                        // 사진이 애초에 없었을 경우
+                        if(errorMessage == "null"){
+                            closeAfterSuccess()
+                        }else{
+                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
+
+                            // log error message
+                            Log.d("error", errorMessage)
+                        }
                     }
                 }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/MyPetActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/MyPetActivity.kt
@@ -27,7 +27,6 @@ class MyPetActivity : AppCompatActivity() {
         binding = ActivityMyPetBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // hide action bar
         supportActionBar?.hide()
 
         // get fragment type and show it(for first launch)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -60,8 +60,9 @@ class CreateUpdatePetFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // view binding
         _binding = FragmentCreateUpdatePetBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         return binding.root
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -91,7 +91,6 @@ class CreateUpdatePetFragment : Fragment() {
             myPetViewModel.petBirthDateValue = dayOfMonth
         }
 
-        // for view restore
         restoreState()
 
         // for pet photo picker
@@ -192,7 +191,6 @@ class CreateUpdatePetFragment : Fragment() {
             }
         }
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentCreateUpdatePetParentLayout)
     }
 
@@ -277,7 +275,6 @@ class CreateUpdatePetFragment : Fragment() {
         myPetViewModel.petManagerApiIsLoading = true
         setButtonToLoading()
 
-        // trim text values
         trimTextValues()
 
         // for birth value
@@ -391,10 +388,8 @@ class CreateUpdatePetFragment : Fragment() {
                     if(isViewDestroyed) return
 
                     if(response.isSuccessful) {
-                        // delete copied file
                         File(path).delete()
 
-                        // close after success
                         closeAfterSuccess()
                     }
                     else {
@@ -440,7 +435,6 @@ class CreateUpdatePetFragment : Fragment() {
                         petIdList.add(it.id)
                     }
 
-                    // update pet photo
                     updatePetPhoto(petIdList[petIdList.size - 1], myPetViewModel.petPhotoPathValue)
                 }
                 else {
@@ -464,26 +458,22 @@ class CreateUpdatePetFragment : Fragment() {
         })
     }
 
-    // set button to loading
     private fun setButtonToLoading() {
         binding.confirmButton.visibility = View.GONE
         binding.createPetProgressBar.visibility = View.VISIBLE
     }
 
-    // set button to normal
     private fun setButtonToNormal() {
         binding.confirmButton.visibility = View.VISIBLE
         binding.createPetProgressBar.visibility = View.GONE
     }
 
-    // for valid check
     private fun checkIsValid() {
         // if valid -> enable confirm button
         binding.confirmButton.isEnabled = myPetViewModel.petNameValue != "" && myPetViewModel.petGenderValue != null &&
                 myPetViewModel.petSpeciesValue != "" && myPetViewModel.petBreedValue != ""
     }
 
-    // for loading check
     private fun checkIsLoading() {
         // if loading -> set button to loading
         if(myPetViewModel.petManagerApiIsLoading) {
@@ -494,7 +484,6 @@ class CreateUpdatePetFragment : Fragment() {
         }
     }
 
-    // for restoring views
     private fun restoreState() {
         // set selected photo(if any)
         if(myPetViewModel.petPhotoPathValue != "") {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -366,16 +366,21 @@ class CreateUpdatePetFragment : Fragment() {
                     if(response.isSuccessful){
                         closeAfterSuccess()
                     }else{
-                        // set api state/button to normal
-                        myPetViewModel.petManagerApiIsLoading = false
-                        setButtonToNormal()
-
-                        // get error message + show(Toast)
                         val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
+                        
+                        // 사진이 애초에 없었을 경우
+                        if(errorMessage == "null"){
+                            closeAfterSuccess()
+                        }else{
+                            // set api state/button to normal
+                            myPetViewModel.petManagerApiIsLoading = false
+                            setButtonToNormal()
 
-                        // log error message
-                        Log.d("error", errorMessage)
+                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
+
+                            // log error message
+                            Log.d("error", errorMessage)
+                        }
                     }
                 }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -361,9 +361,7 @@ class CreateUpdatePetFragment : Fragment() {
                     call: Call<DeletePetPhotoResDto>,
                     response: Response<DeletePetPhotoResDto>
                 ) {
-                    if(isViewDestroyed){
-                        return
-                    }
+                    if(isViewDestroyed) return
 
                     if(response.isSuccessful){
                         closeAfterSuccess()
@@ -382,9 +380,7 @@ class CreateUpdatePetFragment : Fragment() {
                 }
 
                 override fun onFailure(call: Call<DeletePetPhotoResDto>, t: Throwable) {
-                    if(isViewDestroyed){
-                        return
-                    }
+                    if(isViewDestroyed) return
 
                     // set api state/button to normal
                     myPetViewModel.petManagerApiIsLoading = false

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -255,12 +255,7 @@ class CreateUpdatePetFragment : Fragment() {
                     myPetViewModel.petManagerApiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -271,9 +266,7 @@ class CreateUpdatePetFragment : Fragment() {
                 myPetViewModel.petManagerApiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -326,12 +319,7 @@ class CreateUpdatePetFragment : Fragment() {
                     myPetViewModel.petManagerApiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -342,9 +330,7 @@ class CreateUpdatePetFragment : Fragment() {
                 myPetViewModel.petManagerApiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -376,10 +362,7 @@ class CreateUpdatePetFragment : Fragment() {
                             myPetViewModel.petManagerApiIsLoading = false
                             setButtonToNormal()
 
-                            Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                            // log error message
-                            Log.d("error", errorMessage)
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
                 }
@@ -391,9 +374,7 @@ class CreateUpdatePetFragment : Fragment() {
                     myPetViewModel.petManagerApiIsLoading = false
                     setButtonToNormal()
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             }
             )
@@ -421,12 +402,7 @@ class CreateUpdatePetFragment : Fragment() {
                         myPetViewModel.petManagerApiIsLoading = false
                         setButtonToNormal()
 
-                        // get error message + show(Toast)
-                        val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                        // log error message
-                        Log.d("error", errorMessage)
+                        Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                     }
                 }
 
@@ -437,9 +413,7 @@ class CreateUpdatePetFragment : Fragment() {
                     myPetViewModel.petManagerApiIsLoading = false
                     setButtonToNormal()
 
-                    // show(Toast)/log error message
-                    Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                    Log.d("error", t.message.toString())
+                    Util.showToastAndLog(requireContext(), t.message.toString())
                 }
             })
         }
@@ -474,12 +448,7 @@ class CreateUpdatePetFragment : Fragment() {
                     myPetViewModel.petManagerApiIsLoading = false
                     setButtonToNormal()
 
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -490,9 +459,7 @@ class CreateUpdatePetFragment : Fragment() {
                 myPetViewModel.petManagerApiIsLoading = false
                 setButtonToNormal()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
@@ -159,18 +159,12 @@ class PetListAdapter(private val startDragListener: OnStartDragListener, private
                     (view as ImageView).setImageBitmap(BitmapFactory.decodeStream(response.body()!!.byteStream()))
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(context, response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                // log error message
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(context, t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -142,21 +142,14 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
                     }
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchPetResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -63,6 +63,8 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
     ): View? {
         // view binding
         _binding = FragmentPetManagerBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val root: View = binding.root
 
         // initialize RecyclerView

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -128,7 +128,6 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
 
                     // if RecyclerView items not yet added
                     if(adapter.itemCount == 0) {
-                        // update list order + reorder
                         updatePetListOrder(petListApi)
                         reorderPetList(petListApi)
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -159,12 +159,7 @@ class PetProfileFragment : Fragment(){
                     activity?.finish()
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
@@ -175,9 +170,7 @@ class PetProfileFragment : Fragment(){
                 myPetViewModel.petManagerApiIsLoading = false
                 enableButton()
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -39,8 +39,9 @@ class PetProfileFragment : Fragment(){
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // view binding
         _binding = FragmentPetProfileBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
+
         val view = binding.root
 
         // save pet data to ViewModel(for pet profile) if not already loaded

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -63,7 +63,6 @@ class PetProfileFragment : Fragment(){
     override fun onStart() {
         super.onStart()
 
-        // check if API is loading
         checkIsLoading()
 
         // for pet update button
@@ -130,7 +129,6 @@ class PetProfileFragment : Fragment(){
         }
     }
 
-    // delete pet
     private fun deletePet() {
         // set api state/button to loading
         myPetViewModel.petManagerApiIsLoading = true

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
@@ -53,7 +53,6 @@ class PetScheduleEditFragment : Fragment() {
         // for update_pet_schedule
         setViewForUpdate()
 
-        // 상태 로드
         loadState(myPetViewModel)
 
         // Timepicker
@@ -115,7 +114,6 @@ class PetScheduleEditFragment : Fragment() {
 
         addPetNameList()
 
-        // for hiding keyboard
         Util.setupViewsForHideKeyboard(requireActivity(), binding.fragmentPetScheduleEditParentLayout)
 
         return binding.root

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
@@ -214,14 +214,14 @@ class PetScheduleEditFragment : Fragment() {
                 if(response.isSuccessful){
                     activity?.finish()
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_SHORT).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<CreatePetScheduleResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }
@@ -244,14 +244,14 @@ class PetScheduleEditFragment : Fragment() {
                 if(response.isSuccessful){
                     activity?.finish()
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_SHORT).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<UpdatePetScheduleResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
@@ -48,6 +48,7 @@ class PetScheduleEditFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentPetScheduleEditBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         // for update_pet_schedule
         setViewForUpdate()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -54,7 +54,6 @@ class PetScheduleManagerFragment : Fragment() {
         _binding = FragmentPetScheduleManagerBinding.inflate(inflater, container, false)
         isViewDestroyed = false
 
-        // 어뎁터 초기화
         initializeAdapter()
 
         // 추가 버튼

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -52,6 +52,7 @@ class PetScheduleManagerFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentPetScheduleManagerBinding.inflate(inflater, container, false)
+        isViewDestroyed = false
 
         // 어뎁터 초기화
         initializeAdapter()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -137,7 +137,7 @@ class PetScheduleManagerFragment : Fragment() {
                     }
 
                     override fun onFailure(call: Call<DeletePetScheduleResDto>, t: Throwable) {
-                        Log.e("ScheduleAdapter", t.message.toString())
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -160,14 +160,14 @@ class PetScheduleManagerFragment : Fragment() {
                         if(response.isSuccessful){
                             // Do nothing
                         }else{
-                            Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_SHORT).show()
+                            Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
                     }
 
                     override fun onFailure(call: Call<UpdatePetScheduleResDto>, t: Throwable) {
                         if(isViewDestroyed) return
 
-                        Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
+                        Util.showToastAndLog(requireContext(), t.message.toString())
                     }
                 })
             }
@@ -208,14 +208,14 @@ class PetScheduleManagerFragment : Fragment() {
                     adapter.setDataSet(dataSet)
                     adapter.notifyDataSetChanged()
                 }else{
-                    Toast.makeText(context, Util.getMessageFromErrorBody(response.errorBody()!!), Toast.LENGTH_SHORT).show()
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<FetchPetScheduleResDto>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                Toast.makeText(context, "${t.message}", Toast.LENGTH_SHORT).show()
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageActivity.kt
@@ -13,7 +13,6 @@ class WelcomePageActivity : AppCompatActivity() {
         binding = ActivityWelcomePageBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // 액션바 숨김
         supportActionBar?.hide()
 
         if(supportFragmentManager.findFragmentById(R.id.welcome_page_activity_fragment_container) == null){

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
@@ -32,7 +32,6 @@ class WelcomePageProfileFragment : Fragment() {
 
     private var isViewDestroyed = false
 
-    // Account DAO
     private var accountData: Account? = null
 
     override fun onCreateView(

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
@@ -40,6 +40,7 @@ class WelcomePageProfileFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentWelcomePageProfileBinding.inflate(layoutInflater)
+        isViewDestroyed = false
 
         return binding.root
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
@@ -115,20 +115,14 @@ class WelcomePageProfileFragment : Fragment() {
                     requireActivity().overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left)
                 }
                 else {
-                    // get error message + show(Toast)
-                    val errorMessage = Util.getMessageFromErrorBody(response.errorBody()!!)
-
-                    // log error message
-                    Log.d("error", errorMessage)
+                    Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                 }
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 if(isViewDestroyed) return
 
-                // show(Toast)/log error message
-                Toast.makeText(context, t.message.toString(), Toast.LENGTH_LONG).show()
-                Log.d("error", t.message.toString())
+                Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
@@ -106,6 +106,8 @@ class WelcomePageProfileFragment : Fragment() {
                 call: Call<ResponseBody>,
                 response: Response<ResponseBody>
             ) {
+                if(isViewDestroyed) return
+
                 if(response.isSuccessful) {
                     accountLookupIntent.putExtra("photoByteArray", response.body()!!.byteStream().readBytes())
 

--- a/client/android/app/src/main/res/layout/activity_search.xml
+++ b/client/android/app/src/main/res/layout/activity_search.xml
@@ -61,6 +61,7 @@
                 android:layout_weight="1"
                 android:maxLength="20"
                 android:inputType="text"
+                android:imeOptions="actionSearch"
                 android:theme="@style/onSelectedThemeCarrot"/>
 
             <TextView

--- a/client/android/app/src/main/res/layout/fragment_create_account_user_info.xml
+++ b/client/android/app/src/main/res/layout/fragment_create_account_user_info.xml
@@ -70,6 +70,7 @@
                 android:drawableStart="@drawable/ic_baseline_email_24"
                 android:drawablePadding="4dp"
                 android:inputType="textEmailAddress"
+                android:imeOptions="actionDone"
                 android:hint="@string/email_hint"
                 android:theme="@style/onSelectedThemeCarrot"/>
 

--- a/client/android/app/src/main/res/layout/fragment_create_update_pet.xml
+++ b/client/android/app/src/main/res/layout/fragment_create_update_pet.xml
@@ -232,6 +232,7 @@
                             android:layout_height="wrap_content"
                             android:hint="@string/pet_species_hint"
                             android:inputType="textPersonName"
+                            android:nextFocusDown="@id/pet_breed_input"
                             android:maxLength="8"
                             android:theme="@style/onSelectedThemeCarrot" />
 
@@ -256,6 +257,7 @@
                             android:layout_height="wrap_content"
                             android:hint="@string/pet_breed_hint"
                             android:inputType="textPersonName"
+                            android:imeOptions="actionDone"
                             android:maxLength="8"
                             android:theme="@style/onSelectedThemeCarrot" />
 

--- a/client/android/app/src/main/res/layout/fragment_create_update_post.xml
+++ b/client/android/app/src/main/res/layout/fragment_create_update_post.xml
@@ -262,6 +262,7 @@
                         android:layout_toEndOf="@id/hashtag_icon"
                         android:inputType="text"
                         android:maxLength="20"
+                        android:imeOptions="actionGo"
                         android:textSize="16dp"
                         android:theme="@style/onSelectedThemeCarrot"/>
 


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
API Calling을 할 때 response.isSuccessful이 false이거나, API 호출이 실패할 경우(onFailure) 출력하는 메시지 코드를 통일하였습니다.
추가로 불필요한 주석들을 삭제하였습니다.

## 변경사항
 - response.isSuccessful이 false일 때 showToastAndLogForFailedResponse()을 호출하며, onFailure에서 showToastAndLog()를 호출합니다.
 - 불필요한 주석들을 삭제하였습니다. 코드 리딩을 도와주는 것이 주석인데, 배보다 배꼽이 더 커진 느낌이 들었습니다. 가장 간단한 예시들은 다음과 같습니다.
![image](https://user-images.githubusercontent.com/58168528/133618809-cbfa1907-9fb3-40ac-95a4-fef1407af0e5.png)
![image](https://user-images.githubusercontent.com/58168528/133618832-9ffbc64d-5d2a-4622-94b5-fcbd2add6ef9.png)
로버트 C. 마틴의 Clean Code의 4장 주석부분을 기반으로 판단하였습니다. 자세한 내용은 책에 기술되어있으나, 목차만 봐도 어느정도 이해가 될 것 같아서 관련 사진을 첨부합니다.
![image](https://user-images.githubusercontent.com/58168528/133619667-0bbc98c6-228a-48f1-89a4-ec1984f6ff75.png)
다만 이 부분은 주관이 개입하는 영역이므로 자유롭게 의견을 주고받으면 좋을 듯 합니다.
 
## 비고
**해당 branch가 Feature/convenience-improvement에서 분기되어있으므로, 9/16일부터 작성된 commits가 이 branch의 변경사항에 해당합니다.**


## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
