### PR TITLE
[feature/empty-list-notification] 리스트가 비어있을 경우 배경에 문구 띄우기 및 일부 버그 수정

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -81,18 +81,7 @@ class CommunityFragment : Fragment() {
                         adapter.notifyItemInserted(0)
                         adapter.notifyItemRangeChanged(0, adapter.itemCount)
 
-                        // 최하단 post를 삭제해야한다. 이 작업으로, 다음 페이지를 로드할 때
-                        /* 최하단 post를 로드하여 이 post가 총 2번 나타나는 버그를 방지한다.
-                        if(adapter.itemCount >= 1){
-                            adapter.removeItem(adapter.itemCount-1)
-                            adapter.notifyItemRemoved(adapter.itemCount-1)
-                            adapter.notifyItemRangeRemoved(adapter.itemCount-1, 1)
-                        }
-                        */
-
                         binding.recyclerViewPost.scrollToPosition(0)
-
-                        topPostId = postId
                     }
                 }
             }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -430,6 +430,10 @@ class CommunityFragment : Fragment() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful){
+                    // set notification view
+                    val visibility = if(response.body()?.postList?.size != 0) View.GONE else View.VISIBLE
+                    binding.emptyPostListNotification.visibility = visibility
+
                     response.body()!!.postList?.let {
                         if(it.isNotEmpty()){
                             // 추가로, 로딩 중에 뷰가 제거되면 오류(Inconsistency detected)가 나는데, 칼럼이 생긴 이후에도 발생 시 fix할 것

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityFragment.kt
@@ -502,6 +502,7 @@ class CommunityFragment : Fragment() {
     }
 
     private fun resetPostData(){
+        topPostId = null
         pageIndex = 1
         adapter.resetItem()
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
@@ -203,6 +203,21 @@ class CommunityCommentFragment : Fragment() {
                 }
             })
         }
+
+        // set adapter item change observer
+        adapter.registerAdapterDataObserver(object: RecyclerView.AdapterDataObserver() {
+            override fun onChanged() {
+                super.onChanged()
+
+                setEmptyNotificationView(adapter.itemCount)
+            }
+
+            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                super.onItemRangeRemoved(positionStart, itemCount)
+
+                setEmptyNotificationView(adapter.itemCount)
+            }
+        })
     }
 
     private fun setViewForReply(id: Long, nickname: String) {
@@ -300,10 +315,6 @@ class CommunityCommentFragment : Fragment() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful){
-                    // set notification view
-                    val visibility = if(response.body()?.commentList?.size != 0) View.GONE else View.VISIBLE
-                    binding.emptyCommentListNotification.visibility = visibility
-
                     response.body()!!.commentList?.let {
                         if(it.isNotEmpty()){
                             // Set topCommentId
@@ -494,5 +505,11 @@ class CommunityCommentFragment : Fragment() {
                 Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
+    }
+
+    private fun setEmptyNotificationView(itemCount: Int?) {
+        // set notification view
+        val visibility = if(itemCount != 0) View.GONE else View.VISIBLE
+        binding.emptyCommentListNotification.visibility = visibility
     }
 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
@@ -300,6 +300,10 @@ class CommunityCommentFragment : Fragment() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful){
+                    // set notification view
+                    val visibility = if(response.body()?.commentList?.size != 0) View.GONE else View.VISIBLE
+                    binding.emptyCommentListNotification.visibility = visibility
+
                     response.body()!!.commentList?.let {
                         if(it.isNotEmpty()){
                             // Set topCommentId

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateViewModelFactory
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.databinding.FragmentFollowerBinding
@@ -57,6 +58,18 @@ class FollowerFragment : Fragment() {
         binding.followerRecyclerView.adapter = followerAdapter
         binding.followerRecyclerView.layoutManager = LinearLayoutManager(activity)
 
+        // Set adapter item change observer
+        followerAdapter.registerAdapterDataObserver(object: RecyclerView.AdapterDataObserver() {
+            override fun onChanged() {
+                super.onChanged()
+                setEmptyFollowerView(followerAdapter.itemCount)
+            }
+            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                super.onItemRangeRemoved(positionStart, itemCount)
+                setEmptyFollowerView(followerAdapter.itemCount)
+            }
+        })
+
         // for swipe refresh
         binding.followerSwipeRefreshLayout.setOnRefreshListener {
             updateRecyclerView()
@@ -79,6 +92,11 @@ class FollowerFragment : Fragment() {
         super.onResume()
 
         updateRecyclerView()
+    }
+
+    private fun setEmptyFollowerView(itemCount: Int){
+        val visibility = if(itemCount != 0) View.GONE else View.VISIBLE
+        binding.emptyFollowerList.visibility = visibility
     }
 
     private fun updateRecyclerView() {  // update followingIdList -> fetch follower

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.SavedStateViewModelFactory
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.databinding.FragmentFollowingBinding
@@ -70,6 +71,18 @@ class FollowingFragment : Fragment() {
         binding.followingRecyclerView.setHasFixedSize(true)
         binding.followingRecyclerView.adapter = followingAdapter
         binding.followingRecyclerView.layoutManager = LinearLayoutManager(activity)
+
+        // Set adapter item change observer
+        followingAdapter.registerAdapterDataObserver(object: RecyclerView.AdapterDataObserver() {
+            override fun onChanged() {
+                super.onChanged()
+                setEmptyFollowingView(followingAdapter.itemCount)
+            }
+            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                super.onItemRangeRemoved(positionStart, itemCount)
+                setEmptyFollowingView(followingAdapter.itemCount)
+            }
+        })
     }
 
     override fun onResume() {
@@ -77,6 +90,11 @@ class FollowingFragment : Fragment() {
 
         // update RecyclerView
         fetchFollowing()
+    }
+
+    private fun setEmptyFollowingView(itemCount: Int){
+        val visibility = if(itemCount != 0) View.GONE else View.VISIBLE
+        binding.emptyFollowingList.visibility = visibility
     }
 
     private fun fetchFollowing() {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -126,6 +126,10 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
                         myPetViewModel.addPetNameForId(it.id, it.name)
                     }
 
+                    // set notification view
+                    val visibility = if(petListApi.size != 0) View.GONE else View.VISIBLE
+                    binding.emptyPetListNotification.visibility = visibility
+
                     // if RecyclerView items not yet added
                     if(adapter.itemCount == 0) {
                         updatePetListOrder(petListApi)
@@ -240,7 +244,8 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
                     break
                 }
             }
-            binding.myPetListRecyclerView.smoothScrollToPosition(petList.size - 1)
+            val position = if(petList.size >= 1) petList.size else 0
+            binding.myPetListRecyclerView.smoothScrollToPosition(position)
             updatePetListOrder(apiResponse)
             return
         }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -107,6 +107,10 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful) {
+                    // set notification view
+                    val visibility = if(response.body()?.petList?.size != 0) View.GONE else View.VISIBLE
+                    binding.emptyPetListNotification.visibility = visibility
+
                     val petListApi: ArrayList<PetListItem> = ArrayList()
                     response.body()?.petList?.map {
                         val item = PetListItem()
@@ -125,10 +129,6 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
 
                         myPetViewModel.addPetNameForId(it.id, it.name)
                     }
-
-                    // set notification view
-                    val visibility = if(petListApi.size != 0) View.GONE else View.VISIBLE
-                    binding.emptyPetListNotification.visibility = visibility
 
                     // if RecyclerView items not yet added
                     if(adapter.itemCount == 0) {

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -15,6 +15,7 @@ import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import androidx.work.*
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
@@ -178,6 +179,21 @@ class PetScheduleManagerFragment : Fragment() {
 
         binding.petScheduleListRecyclerView.adapter = adapter
         binding.petScheduleListRecyclerView.layoutManager = LinearLayoutManager(activity)
+
+        // set adapter item change observer
+        adapter.registerAdapterDataObserver(object: RecyclerView.AdapterDataObserver() {
+            override fun onChanged() {
+                super.onChanged()
+
+                setEmptyNotificationView(adapter.itemCount)
+            }
+
+            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                super.onItemRangeRemoved(positionStart, itemCount)
+
+                setEmptyNotificationView(adapter.itemCount)
+            }
+        })
     }
 
     private fun updateAdapterDataSetByFetchPetSchedule(){
@@ -195,10 +211,6 @@ class PetScheduleManagerFragment : Fragment() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful){
-                    // set notification view
-                    val visibility = if(response.body()?.petScheduleList?.size != 0) View.GONE else View.VISIBLE
-                    binding.emptyPetScheduleListNotification.visibility = visibility
-
                     // dataSet에 값 저장
                     response.body()?.petScheduleList?.map{
                         dataSet.add(PetSchedule(
@@ -221,5 +233,11 @@ class PetScheduleManagerFragment : Fragment() {
                 Util.showToastAndLog(requireContext(), t.message.toString())
             }
         })
+    }
+
+    private fun setEmptyNotificationView(itemCount: Int) {
+        // set notification view
+        val visibility = if(itemCount != 0) View.GONE else View.VISIBLE
+        binding.emptyPetScheduleListNotification.visibility = visibility
     }
 }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -195,6 +195,10 @@ class PetScheduleManagerFragment : Fragment() {
                 if(isViewDestroyed) return
 
                 if(response.isSuccessful){
+                    // set notification view
+                    val visibility = if(response.body()?.petScheduleList?.size != 0) View.GONE else View.VISIBLE
+                    binding.emptyPetScheduleListNotification.visibility = visibility
+
                     // dataSet에 값 저장
                     response.body()?.petScheduleList?.map{
                         dataSet.add(PetSchedule(

--- a/client/android/app/src/main/res/layout/fragment_community.xml
+++ b/client/android/app/src/main/res/layout/fragment_community.xml
@@ -16,9 +16,8 @@
         android:text="@string/empty_post_list_notification"
         android:textAlignment="center"
         android:textColor="@color/gray"
-        android:textSize="18sp"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        android:textSize="16sp"
+        android:visibility="visible" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/layout_swipe_refresh"

--- a/client/android/app/src/main/res/layout/fragment_community.xml
+++ b/client/android/app/src/main/res/layout/fragment_community.xml
@@ -8,6 +8,18 @@
     android:paddingBottom="@dimen/nav_height"
     >
 
+    <TextView
+        android:id="@+id/empty_post_list_notification"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/empty_post_list_notification"
+        android:textAlignment="center"
+        android:textColor="@color/gray"
+        android:textSize="18sp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/layout_swipe_refresh"
         android:layout_width="match_parent"

--- a/client/android/app/src/main/res/layout/fragment_community_comment.xml
+++ b/client/android/app/src/main/res/layout/fragment_community_comment.xml
@@ -45,6 +45,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@id/layout_comment_input">
 
+        <TextView
+            android:id="@+id/empty_comment_list_notification"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/empty_comment_list_notification"
+            android:textAlignment="center"
+            android:textColor="@color/gray"
+            android:textSize="18sp"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_view_comment"
             android:layout_width="match_parent"

--- a/client/android/app/src/main/res/layout/fragment_community_comment.xml
+++ b/client/android/app/src/main/res/layout/fragment_community_comment.xml
@@ -37,13 +37,13 @@
             android:text="@string/comment"/>
     </RelativeLayout>
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/layout_swipe_refresh"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_back_button"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toTopOf="@id/layout_comment_input"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/layout_comment_input">
+        app:layout_constraintTop_toBottomOf="@id/layout_back_button">
 
         <TextView
             android:id="@+id/empty_comment_list_notification"
@@ -53,9 +53,17 @@
             android:text="@string/empty_comment_list_notification"
             android:textAlignment="center"
             android:textColor="@color/gray"
-            android:textSize="18sp"
-            android:visibility="gone"
-            tools:visibility="visible" />
+            android:textSize="16sp"
+            android:visibility="visible" />
+    </FrameLayout>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/layout_swipe_refresh"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_back_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/layout_comment_input">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_view_comment"

--- a/client/android/app/src/main/res/layout/fragment_follower.xml
+++ b/client/android/app/src/main/res/layout/fragment_follower.xml
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/empty_follower_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/empty_follower_list"
+        android:textAlignment="center"
+        android:textColor="@color/gray"
+        android:textSize="16sp"
+        android:visibility="visible"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/follower_swipe_refresh_layout"
@@ -16,4 +32,4 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/client/android/app/src/main/res/layout/fragment_follower.xml
+++ b/client/android/app/src/main/res/layout/fragment_follower.xml
@@ -2,8 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/empty_follower_list"

--- a/client/android/app/src/main/res/layout/fragment_following.xml
+++ b/client/android/app/src/main/res/layout/fragment_following.xml
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/empty_following_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/empty_following_list"
+        android:textAlignment="center"
+        android:textColor="@color/gray"
+        android:textSize="16sp"
+        android:visibility="visible"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/following_swipe_refresh_layout"
@@ -16,4 +31,4 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/client/android/app/src/main/res/layout/fragment_pet_manager.xml
+++ b/client/android/app/src/main/res/layout/fragment_pet_manager.xml
@@ -1,39 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.myPet.petManager.PetManagerFragment">
 
-    <TextView
-        android:id="@+id/empty_pet_list_notification"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="@string/empty_pet_list_notification"
-        android:textAlignment="center"
-        android:textColor="@color/gray"
-        android:textSize="18sp"
-        android:visibility="gone"
-        tools:visibility="visible" />
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/empty_pet_list_notification"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/empty_pet_list_notification"
+            android:textAlignment="center"
+            android:textColor="@color/gray"
+            android:textSize="16sp"
+            android:visibility="visible" />
+    </FrameLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/my_pet_list_recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false" />
+        android:clipToPadding="false"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/create_pet_fab"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
         android:src="@drawable/ic_baseline_add_24"
-        app:backgroundTint="@color/carrot" />
+        android:layout_margin="16dp"
+        app:backgroundTint="@color/carrot"
+        app:tint="@color/white"
+        />
 
-</FrameLayout>
+</RelativeLayout>

--- a/client/android/app/src/main/res/layout/fragment_pet_manager.xml
+++ b/client/android/app/src/main/res/layout/fragment_pet_manager.xml
@@ -15,7 +15,8 @@
         android:textAlignment="center"
         android:textColor="@color/gray"
         android:textSize="18sp"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/my_pet_list_recyclerView"

--- a/client/android/app/src/main/res/layout/fragment_pet_manager.xml
+++ b/client/android/app/src/main/res/layout/fragment_pet_manager.xml
@@ -1,28 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.myPet.petManager.PetManagerFragment">
 
+    <TextView
+        android:id="@+id/empty_pet_list_notification"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/empty_pet_list_notification"
+        android:textAlignment="center"
+        android:textColor="@color/gray"
+        android:textSize="18sp"
+        android:visibility="gone" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/my_pet_list_recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false"/>
+        android:clipToPadding="false" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/create_pet_fab"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
         android:src="@drawable/ic_baseline_add_24"
-        android:layout_margin="16dp"
-        app:backgroundTint="@color/carrot"
-        app:tint="@color/white"
-        />
+        app:backgroundTint="@color/carrot" />
 
-</RelativeLayout>
+</FrameLayout>

--- a/client/android/app/src/main/res/layout/fragment_pet_schedule_manager.xml
+++ b/client/android/app/src/main/res/layout/fragment_pet_schedule_manager.xml
@@ -14,9 +14,8 @@
         android:text="@string/empty_pet_schedule_list_notification"
         android:textAlignment="center"
         android:textColor="@color/gray"
-        android:textSize="18sp"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        android:textSize="16sp"
+        android:visibility="visible" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/pet_schedule_list_recycler_view"

--- a/client/android/app/src/main/res/layout/fragment_pet_schedule_manager.xml
+++ b/client/android/app/src/main/res/layout/fragment_pet_schedule_manager.xml
@@ -6,6 +6,18 @@
     android:layout_height="match_parent"
     tools:context=".ui.myPet.petScheduleManager.PetScheduleManagerFragment">
 
+    <TextView
+        android:id="@+id/empty_pet_schedule_list_notification"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/empty_pet_schedule_list_notification"
+        android:textAlignment="center"
+        android:textColor="@color/gray"
+        android:textSize="18sp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/pet_schedule_list_recycler_view"
         android:layout_width="match_parent"

--- a/client/android/app/src/main/res/values/colors.xml
+++ b/client/android/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="gray">#F2727272</color>
     <color name="border_line">#DFE3E6</color>
     <color name="emerald">#2ECC71</color>
     <color name="sunflower">#F1C40F</color>

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="delete_pet_button">펫 삭제</string>
     <string name="delete_pet_dialog_message">펫을 삭제할까요?</string>
     <string name="delete_pet_successful">펫이 삭제되었어요!</string>
+    <string name="empty_pet_list_notification">아직 반려동물이 추가되지 않았네요.\n나의 반려동물을 추가해보세요!</string>
 
     <!-- WelcomePage Fragment -->
     <string name="skip_button">SKIP</string>
@@ -113,6 +114,7 @@
     <string name="pet_schedule_update_title">일정 편집</string>
     <string name="pet_name_list_title">반려동물을 선택하세요.</string>
     <string name="memo_title">메모</string>
+    <string name="empty_pet_schedule_list_notification">아직 일정이 추가되지 않았네요.\n반려동물을 위한 일정을 추가해보세요!</string>
 
     <!-- Map Fragment -->
     <string name="cafe">카페</string>
@@ -214,6 +216,7 @@
     <string name="update_post_successful">글 수정에 성공했어요!</string>
     <string name="delete_post_successful">글 삭제에 성공했어요!</string>
     <string name="post_data_loading_message">글 정보 불러오는 중…</string>
+    <string name="empty_post_list_notification">불러올 포스트가 없어요.\n새 포스트를 추가해보세요!</string>
 
     <!-- Community Fragment -->
     <string name="comment">댓글</string>
@@ -227,6 +230,7 @@
     <string name="load_reply_title">답글 불러오기</string>
     <string name="load_prev_reply_title">이전 답글 불러오기</string>
     <string name="no_more_reply">모든 답글을 불러왔습니다.</string>
+    <string name="empty_comment_list_notification">아직 댓글이 없어요.\n새 댓글을 추가해보세요!</string>
 
     <!-- Follower/Following Fragment -->
     <string name="follower_following_menu_title">팔로워/팔로잉</string>

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -245,6 +245,8 @@
     <string name="account_does_not_exist_exception_message">해당 유저가 존재하지 않아요!</string>
     <string name="fetched_self_exception_message">나 자신은 영원한 인생의 친구입니다.</string>
     <string name="unfollow_confirm_dialog_message">님을 언팔로우 할까요?</string>
+    <string name="empty_follower_list">아직 팔로워가 없어요.\n친구들에게 나를 알려 팔로워를 모아보세요!</string>
+    <string name="empty_following_list">아직 팔로잉하는 상대가 없어요.\n팔로잉할 상대를 찾아보세요!</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -99,7 +99,7 @@
     <string name="delete_pet_button">펫 삭제</string>
     <string name="delete_pet_dialog_message">펫을 삭제할까요?</string>
     <string name="delete_pet_successful">펫이 삭제되었어요!</string>
-    <string name="empty_pet_list_notification">아직 반려동물이 추가되지 않았네요.\n나의 반려동물을 추가해보세요!</string>
+    <string name="empty_pet_list_notification">아직 반려동물이 추가되지 않았어요.\n나의 반려동물을 추가해보세요!</string>
 
     <!-- WelcomePage Fragment -->
     <string name="skip_button">SKIP</string>
@@ -114,7 +114,7 @@
     <string name="pet_schedule_update_title">일정 편집</string>
     <string name="pet_name_list_title">반려동물을 선택하세요.</string>
     <string name="memo_title">메모</string>
-    <string name="empty_pet_schedule_list_notification">아직 일정이 추가되지 않았네요.\n반려동물을 위한 일정을 추가해보세요!</string>
+    <string name="empty_pet_schedule_list_notification">아직 일정이 추가되지 않았어요.\n반려동물을 위한 일정을 추가해보세요!</string>
 
     <!-- Map Fragment -->
     <string name="cafe">카페</string>


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
- 리스트(반려동물, 스케줄, 댓글 등)가 비어있을 경우 '~가 없어요. ~를 추가해보세요!' 형식의 배경 문구 띄우는 기능 추가

## 변경사항
- 배경 문구
  - fragment_community, fragment_community_comment, fragment_pet_manager, fragment_pet_schedule_manager 레이아웃에 TextView 추가
  - PetManagerFragment, PetScheduleManagerFragment, CommunityFragment, CommunityCommentFragment 코드에 AdapterDataObserver로 adapter의 item 개수를 업데이트 받아서 setEmptyNotificationView() 메소드로 배경 문구의 visibility를 설정하는 로직 추가
    - AdapterDataObserver가 Notify를 받을 수 있도록 Create/Delete 로직에 adapter.notiftyDataSetOOO 메소드 추가 
  - string.xml에 배경 문구 문자열 추가
- 버그 수정
  - 반려동물 아이템이 하나 남았을 때 반려동물을 삭제하면, 앱이 강제종료되는 버그 수정 (PetManagerFragment의 smoothScrollToPosition(position)에서 position이 음수가 되어 invalid target position이 발생하는 문제)
  - 포스트를 생성하면 최하단 포스트만 삭제되는 현상 임시 수정 (다음 페이지를 로드할 때 최하단 post가 2번 나타나는 것을 방지하기 위한 코드만 작동하고, 다시 최하단 post가 로드되지 않아 발생하는 문제)
 
## 비고
- 배경 문구 띄움 예시
<img src="https://user-images.githubusercontent.com/70474071/133955253-12a34801-c859-40db-9109-a215c65b5b16.png" width="50%"/>

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
