### PR TITLE
[Feature/pet-profile-link] 상대 계정 클릭 시 해당 펫 프로필로 이동 구현

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
@@ -8,7 +8,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.fragment.app.setFragmentResult
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.databinding.FragmentUpdateCommentBinding
@@ -16,7 +15,6 @@ import com.sju18001.petmanagement.restapi.RetrofitBuilder
 import com.sju18001.petmanagement.restapi.SessionManager
 import com.sju18001.petmanagement.restapi.dto.UpdateCommentReqDto
 import com.sju18001.petmanagement.restapi.dto.UpdateCommentResDto
-import com.sju18001.petmanagement.ui.community.comment.CommunityCommentActivity
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
@@ -3,13 +3,11 @@ package com.sju18001.petmanagement.ui.community.followerFollowing
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.os.Build
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.RecyclerView
 import com.sju18001.petmanagement.R

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
@@ -2,11 +2,9 @@ package com.sju18001.petmanagement.ui.community.followerFollowing
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateViewModelFactory

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
@@ -1,14 +1,10 @@
 package com.sju18001.petmanagement.ui.community.followerFollowing
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateViewModelFactory
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
@@ -4,13 +4,11 @@ import android.app.AlertDialog
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.os.Build
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.RecyclerView
 import com.sju18001.petmanagement.R

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
@@ -1,13 +1,10 @@
 package com.sju18001.petmanagement.ui.community.followerFollowing
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.SavedStateViewModelFactory
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
@@ -28,6 +28,7 @@ import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.databinding.FragmentPostBinding
 import com.sju18001.petmanagement.restapi.RetrofitBuilder
 import com.sju18001.petmanagement.restapi.SessionManager
+import com.sju18001.petmanagement.restapi.dao.Pet
 import com.sju18001.petmanagement.restapi.dao.Post
 import com.sju18001.petmanagement.restapi.dto.*
 import com.sju18001.petmanagement.ui.community.CommunityViewModel
@@ -389,22 +390,22 @@ class PostFragment : Fragment() {
             }
 
             @RequiresApi(Build.VERSION_CODES.O)
-            override fun fetchPetPhotoAndStartPetProfileFragment(holder: PostListAdapter.ViewHolder, item: Post) {
+            override fun fetchPetPhotoAndStartPetProfileFragment(holder: PostListAdapter.ViewHolder, pet: Pet) {
                 // 사진이 없을 때는 fetch 없이 프래그먼트 시작
-                if(item.pet.photoUrl == null){
-                    startPetProfileFragment(holder, item, null)
+                if(pet.photoUrl == null){
+                    startPetProfileFragment(holder, pet, null)
                     return
                 }
 
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
-                    .fetchPetPhotoReq(FetchPetPhotoReqDto(item.pet.id))
+                    .fetchPetPhotoReq(FetchPetPhotoReqDto(pet.id))
                 call.enqueue(object: Callback<ResponseBody> {
                     override fun onResponse(
                         call: Call<ResponseBody>,
                         response: Response<ResponseBody>
                     ) {
                         if(response.isSuccessful){
-                            startPetProfileFragment(holder, item, response.body()!!.bytes())
+                            startPetProfileFragment(holder, pet, response.body()!!.bytes())
                         }else{
                             Util.showToastAndLogForFailedResponse(requireContext(), response.errorBody())
                         }
@@ -621,27 +622,27 @@ class PostFragment : Fragment() {
 
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun startPetProfileFragment(holder: PostListAdapter.ViewHolder, item: Post, photoByteArray: ByteArray?){
+    private fun startPetProfileFragment(holder: PostListAdapter.ViewHolder, pet: Pet, photoByteArray: ByteArray?){
         // set pet values to Intent
         val petProfileIntent = Intent(holder.itemView.context, MyPetActivity::class.java)
         if(photoByteArray != null) {
             petProfileIntent.putExtra("photoByteArray", photoByteArray)
         }
-        petProfileIntent.putExtra("petId", item.pet.id)
-        petProfileIntent.putExtra("petName", item.pet.name)
-        petProfileIntent.putExtra("petBirth", item.pet.birth)
-        petProfileIntent.putExtra("petSpecies", item.pet.species)
-        petProfileIntent.putExtra("petBreed", item.pet.breed)
-        val petGender = if(item.pet.gender) {
+        petProfileIntent.putExtra("petId", pet.id)
+        petProfileIntent.putExtra("petName", pet.name)
+        petProfileIntent.putExtra("petBirth", pet.birth)
+        petProfileIntent.putExtra("petSpecies", pet.species)
+        petProfileIntent.putExtra("petBreed", pet.breed)
+        val petGender = if(pet.gender) {
             holder.itemView.context.getString(R.string.pet_gender_female_symbol)
         }
         else {
             holder.itemView.context.getString(R.string.pet_gender_male_symbol)
         }
-        val petAge = Period.between(LocalDate.parse(item.pet.birth), LocalDate.now()).years.toString()
+        val petAge = Period.between(LocalDate.parse(pet.birth), LocalDate.now()).years.toString()
         petProfileIntent.putExtra("petGender", petGender)
         petProfileIntent.putExtra("petAge", petAge)
-        petProfileIntent.putExtra("petMessage", item.pet.message)
+        petProfileIntent.putExtra("petMessage", pet.message)
 
         // open activity
         petProfileIntent.putExtra("fragmentType", "pet_profile_community")

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
@@ -644,7 +644,7 @@ class PostFragment : Fragment() {
         petProfileIntent.putExtra("petMessage", item.pet.message)
 
         // open activity
-        petProfileIntent.putExtra("fragmentType", "pet_profile_pet_manager")
+        petProfileIntent.putExtra("fragmentType", "pet_profile_community")
         holder.itemView.context.startActivity(petProfileIntent)
         (requireContext() as Activity).overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left)
     }

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostListAdapter.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.*
 import androidx.annotation.RequiresApi
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.ViewPager2
@@ -47,6 +48,7 @@ class PostListAdapter(private var dataSet: ArrayList<Post>, private var likedCou
         val accountPhotoImage: ImageView = view.findViewById(R.id.account_photo)
         val nicknameTextView: TextView = view.findViewById(R.id.nickname)
         val petNameTextView: TextView = view.findViewById(R.id.pet_name)
+        val layoutUserInfo: ConstraintLayout = view.findViewById(R.id.layout_user_info)
         val dialogButton: ImageButton = view.findViewById(R.id.dialog_button)
 
         val viewPager: ViewPager2 = view.findViewById(R.id.view_pager)
@@ -159,10 +161,7 @@ class PostListAdapter(private var dataSet: ArrayList<Post>, private var likedCou
         val item = dataSet[position]
 
         // 프로필 이동
-        holder.nicknameTextView.setOnClickListener {
-            communityPostListAdapterInterface.fetchPetPhotoAndStartPetProfileFragment(holder, item)
-        }
-        holder.petNameTextView.setOnClickListener {
+        holder.layoutUserInfo.setOnClickListener {
             communityPostListAdapterInterface.fetchPetPhotoAndStartPetProfileFragment(holder, item)
         }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostListAdapter.kt
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.ViewPager2
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
+import com.sju18001.petmanagement.restapi.dao.Pet
 import com.sju18001.petmanagement.restapi.global.FileMetaData
 import com.sju18001.petmanagement.ui.community.post.PostTagListAdapter
 import com.sju18001.petmanagement.ui.myPet.MyPetActivity
@@ -36,7 +37,7 @@ interface PostListAdapterInterface{
     fun setAccountDefaultPhoto(holder: PostListAdapter.ViewHolder)
     fun setPostMedia(holder: PostListAdapter.PostMediaItemCollectionAdapter.ViewPagerHolder, id: Long, index: Int, url: String)
     fun getContext(): Context
-    fun fetchPetPhotoAndStartPetProfileFragment(holder: PostListAdapter.ViewHolder, item: Post)
+    fun fetchPetPhotoAndStartPetProfileFragment(holder: PostListAdapter.ViewHolder, pet: Pet)
 }
 
 private const val MAX_LINE = 5
@@ -162,7 +163,7 @@ class PostListAdapter(private var dataSet: ArrayList<Post>, private var likedCou
 
         // 프로필 이동
         holder.layoutUserInfo.setOnClickListener {
-            communityPostListAdapterInterface.fetchPetPhotoAndStartPetProfileFragment(holder, item)
+            communityPostListAdapterInterface.fetchPetPhotoAndStartPetProfileFragment(holder, item.pet)
         }
 
         // 댓글 버튼

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostListAdapter.kt
@@ -1,6 +1,11 @@
 package com.sju18001.petmanagement.ui.community.post
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.os.Build
 import android.util.Log
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.RecyclerView
@@ -8,6 +13,7 @@ import com.sju18001.petmanagement.restapi.dao.Post
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.annotation.RequiresApi
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.ViewPager2
@@ -15,6 +21,10 @@ import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.restapi.global.FileMetaData
 import com.sju18001.petmanagement.ui.community.post.PostTagListAdapter
+import com.sju18001.petmanagement.ui.myPet.MyPetActivity
+import java.io.ByteArrayOutputStream
+import java.time.LocalDate
+import java.time.Period
 
 interface PostListAdapterInterface{
     fun startCommunityCommentActivity(postId: Long)
@@ -25,6 +35,7 @@ interface PostListAdapterInterface{
     fun setAccountDefaultPhoto(holder: PostListAdapter.ViewHolder)
     fun setPostMedia(holder: PostListAdapter.PostMediaItemCollectionAdapter.ViewPagerHolder, id: Long, index: Int, url: String)
     fun getContext(): Context
+    fun fetchPetPhotoAndStartPetProfileFragment(holder: PostListAdapter.ViewHolder, item: Post)
 }
 
 private const val MAX_LINE = 5
@@ -33,7 +44,7 @@ class PostListAdapter(private var dataSet: ArrayList<Post>, private var likedCou
     lateinit var communityPostListAdapterInterface: PostListAdapterInterface
 
     class ViewHolder(view: View): RecyclerView.ViewHolder(view){
-        val petPhotoImage: ImageView = view.findViewById(R.id.pet_photo)
+        val accountPhotoImage: ImageView = view.findViewById(R.id.account_photo)
         val nicknameTextView: TextView = view.findViewById(R.id.nickname)
         val petNameTextView: TextView = view.findViewById(R.id.pet_name)
         val dialogButton: ImageButton = view.findViewById(R.id.dialog_button)
@@ -56,6 +67,7 @@ class PostListAdapter(private var dataSet: ArrayList<Post>, private var likedCou
         return ViewHolder(view)
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val safePosition = holder.adapterPosition
 
@@ -142,25 +154,36 @@ class PostListAdapter(private var dataSet: ArrayList<Post>, private var likedCou
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun setListenerOnView(holder: ViewHolder, position: Int){
+        val item = dataSet[position]
+
+        // 프로필 이동
+        holder.nicknameTextView.setOnClickListener {
+            communityPostListAdapterInterface.fetchPetPhotoAndStartPetProfileFragment(holder, item)
+        }
+        holder.petNameTextView.setOnClickListener {
+            communityPostListAdapterInterface.fetchPetPhotoAndStartPetProfileFragment(holder, item)
+        }
+
         // 댓글 버튼
         holder.commentButton.setOnClickListener {
-            communityPostListAdapterInterface.startCommunityCommentActivity(dataSet[position].id)
+            communityPostListAdapterInterface.startCommunityCommentActivity(item.id)
         }
 
         // 좋아요 버튼
         holder.createLikeButton.setOnClickListener {
-            communityPostListAdapterInterface.createLike(dataSet[position].id, holder, position)
+            communityPostListAdapterInterface.createLike(item.id, holder, position)
         }
 
         // 좋아요 취소 버튼
         holder.deleteLikeButton.setOnClickListener {
-            communityPostListAdapterInterface.deleteLike(dataSet[position].id, holder, position)
+            communityPostListAdapterInterface.deleteLike(item.id, holder, position)
         }
 
         // ... 버튼 -> Dialog 띄우기
         holder.dialogButton.setOnClickListener {
-            communityPostListAdapterInterface.onClickPostFunctionButton(dataSet[position], position)
+            communityPostListAdapterInterface.onClickPostFunctionButton(item, position)
         }
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -14,8 +14,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResultListener
 import com.google.android.material.snackbar.Snackbar
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.sju18001.petmanagement.MainActivity
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
@@ -32,7 +30,6 @@ import okhttp3.RequestBody
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.lang.reflect.Type
 
 class LoginFragment : Fragment() {
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -4,11 +4,9 @@ import android.app.AlertDialog
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.sju18001.petmanagement.R
@@ -18,7 +16,6 @@ import com.sju18001.petmanagement.restapi.RetrofitBuilder
 import com.sju18001.petmanagement.restapi.SessionManager
 import com.sju18001.petmanagement.restapi.dao.Account
 import com.sju18001.petmanagement.restapi.dto.FetchAccountPhotoReqDto
-import com.sju18001.petmanagement.restapi.dto.FetchAccountResDto
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -35,7 +35,6 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import java.io.File
-import java.util.regex.Pattern
 
 class EditAccountFragment : Fragment() {
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/MyPetActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/MyPetActivity.kt
@@ -36,6 +36,7 @@ class MyPetActivity : AppCompatActivity() {
             val fragment = when(fragmentType){
                 "create_pet" -> CreateUpdatePetFragment()
                 "pet_profile_pet_manager" -> PetProfileFragment()
+                "pet_profile_community" -> PetProfileFragment()
                 else -> PetScheduleEditFragment()
             }
             supportFragmentManager

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -9,7 +9,6 @@ import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
@@ -7,11 +7,9 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
 import android.os.Build
-import android.util.Log
 import android.view.*
 import android.widget.ImageView
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.RecyclerView
 import com.sju18001.petmanagement.R

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -6,11 +6,9 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -28,7 +26,6 @@ import com.sju18001.petmanagement.restapi.dto.FetchPetReqDto
 import com.sju18001.petmanagement.restapi.dto.FetchPetResDto
 import com.sju18001.petmanagement.ui.myPet.MyPetActivity
 import com.sju18001.petmanagement.ui.myPet.MyPetViewModel
-import org.json.JSONObject
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -1,14 +1,10 @@
 package com.sju18001.petmanagement.ui.myPet.petManager
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -5,6 +5,7 @@ import android.app.AlertDialog
 import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -66,11 +67,6 @@ class PetProfileFragment : Fragment(){
         }
         else {
             // TODO: implement logic for username_and_pets_layout
-        }
-
-        // if fragment type is pet_profile_community -> hide username_and_pets_layout
-        if(requireActivity().intent.getStringExtra("fragmentType") == "pet_profile_community") {
-            binding.buttonsLayout.visibility = View.GONE
         }
 
 
@@ -318,7 +314,9 @@ class PetProfileFragment : Fragment(){
             if(myPetViewModel.petMessageValueProfile.isNotEmpty()) {
                 binding.petMessage.visibility = View.VISIBLE
             }
-            binding.buttonsLayout.visibility = View.VISIBLE
+            if(requireActivity().intent.getStringExtra("fragmentType") == "pet_profile_pet_manager"){
+                binding.buttonsLayout.visibility = View.VISIBLE
+            }
 
             binding.petProfileMainScrollView.scrollTo(0, 0)
             (binding.petProfileMainScrollView.layoutParams as ViewGroup.MarginLayoutParams).topMargin = backButtonLayoutHeight

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
@@ -2,18 +2,14 @@ package com.sju18001.petmanagement.ui.myPet.petScheduleManager
 
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.databinding.FragmentPetScheduleEditBinding
@@ -21,13 +17,8 @@ import com.sju18001.petmanagement.restapi.RetrofitBuilder
 import com.sju18001.petmanagement.restapi.SessionManager
 import com.sju18001.petmanagement.restapi.dto.*
 import com.sju18001.petmanagement.ui.myPet.MyPetViewModel
-import okhttp3.MediaType
-import okhttp3.RequestBody
-import okhttp3.ResponseBody
-import org.json.JSONObject
 import retrofit2.Call
 import retrofit2.Callback
-import retrofit2.Converter
 import retrofit2.Response
 import java.time.LocalTime
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -6,17 +6,14 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.work.*
 import com.sju18001.petmanagement.R
 import com.sju18001.petmanagement.controller.Util
 import com.sju18001.petmanagement.databinding.FragmentPetScheduleManagerBinding
@@ -31,9 +28,6 @@ import okhttp3.RequestBody
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.time.Duration
-import java.time.LocalTime
-import java.util.concurrent.TimeUnit
 
 class PetScheduleManagerFragment : Fragment() {
     private var _binding: FragmentPetScheduleManagerBinding? = null

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
@@ -1,9 +1,7 @@
 package com.sju18001.petmanagement.ui.welcomePage
 
 import android.content.Intent
-import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -17,10 +15,7 @@ import com.sju18001.petmanagement.restapi.RetrofitBuilder
 import com.sju18001.petmanagement.restapi.SessionManager
 import com.sju18001.petmanagement.restapi.dao.Account
 import com.sju18001.petmanagement.restapi.dto.FetchAccountPhotoReqDto
-import com.sju18001.petmanagement.restapi.dto.FetchAccountResDto
 import com.sju18001.petmanagement.ui.myPage.MyPageActivity
-import okhttp3.MediaType
-import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback

--- a/client/android/app/src/main/res/layout/fragment_pet_profile.xml
+++ b/client/android/app/src/main/res/layout/fragment_pet_profile.xml
@@ -183,6 +183,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="14dp"
                         android:layout_marginTop="12dp"
+                        android:layout_marginBottom="12dp"
                         android:layout_marginEnd="14dp"
                         android:paddingStart="16dp"
                         android:paddingTop="22dp"
@@ -200,7 +201,11 @@
                     android:id="@+id/buttons_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
+                    android:paddingTop="4dp"
+                    android:paddingLeft="16dp"
+                    android:paddingBottom="12dp"
+                    android:paddingRight="16dp"
+                    android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@id/pet_info_layout"
                     app:layout_constraintBottom_toTopOf="@id/post_fragment_container">
 

--- a/client/android/app/src/main/res/layout/post_item.xml
+++ b/client/android/app/src/main/res/layout/post_item.xml
@@ -21,34 +21,44 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
-        <TextView
-            android:id="@+id/nickname"
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_user_info"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="8dp"
-            android:text="rachmaninoff"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/account_photo"
-            />
-        <TextView
-            android:id="@+id/nickname_footer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="님의 "
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/nickname"
-            />
-        <TextView
-            android:id="@+id/pet_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="몽자"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/nickname_footer"
-            />
+            app:layout_constraintStart_toEndOf="@id/account_photo">
+            <TextView
+                android:id="@+id/nickname"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="rachmaninoff"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                />
+            <TextView
+                android:id="@+id/nickname_footer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="님의 "
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/nickname"
+                />
+            <TextView
+                android:id="@+id/pet_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="몽자"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/nickname_footer"
+                />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <ImageButton
             android:id="@+id/dialog_button"
             android:layout_width="wrap_content"

--- a/client/android/app/src/main/res/layout/post_item.xml
+++ b/client/android/app/src/main/res/layout/post_item.xml
@@ -12,7 +12,7 @@
         app:layout_constraintStart_toStartOf="parent"
         >
         <de.hdodenhof.circleimageview.CircleImageView
-            android:id="@+id/pet_photo"
+            android:id="@+id/account_photo"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:src="@drawable/marker_pet"
@@ -29,7 +29,7 @@
             android:text="rachmaninoff"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/pet_photo"
+            app:layout_constraintStart_toEndOf="@id/account_photo"
             />
         <TextView
             android:id="@+id/nickname_footer"

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/api/PetController.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/api/PetController.java
@@ -65,11 +65,11 @@ public class PetController {
     }
 
     @PostMapping("/api/pet/photo/fetch")
-    public ResponseEntity<?> fetchPetPhoto(Authentication auth, @Valid @RequestBody FetchPetPhotoReqDto reqDto) {
+    public ResponseEntity<?> fetchPetPhoto(@Valid @RequestBody FetchPetPhotoReqDto reqDto) {
         DtoMetadata dtoMetadata;
         byte[] fileBinData;
         try {
-            fileBinData = petServ.fetchPetPhoto(auth, reqDto.getId());
+            fileBinData = petServ.fetchPetPhoto(reqDto.getId());
         } catch (Exception e) {
             logger.warn(e.toString());
             dtoMetadata = new DtoMetadata(e.getMessage(), e.getClass().getName());

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/application/PetService.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/application/PetService.java
@@ -90,8 +90,7 @@ public class PetService {
                 ));
     }
 
-    public byte[] fetchPetPhoto(Authentication auth, Long petId) throws Exception {
-        Account currentAccount = accountServ.fetchCurrentAccount(auth);
+    public byte[] fetchPetPhoto(Long petId) throws Exception {
         Pet currentPet = petRepository.findById(petId)
                 .orElseThrow(() -> new IllegalArgumentException(
                         msgSrc.getMessage("error.pet.notExists", null, Locale.ENGLISH)

--- a/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/application/PetService.java
+++ b/server/src/main/java/com/sju18/petmanagement/domain/pet/pet/application/PetService.java
@@ -92,7 +92,7 @@ public class PetService {
 
     public byte[] fetchPetPhoto(Authentication auth, Long petId) throws Exception {
         Account currentAccount = accountServ.fetchCurrentAccount(auth);
-        Pet currentPet = petRepository.findByOwnernameAndId(currentAccount.getUsername(), petId)
+        Pet currentPet = petRepository.findById(petId)
                 .orElseThrow(() -> new IllegalArgumentException(
                         msgSrc.getMessage("error.pet.notExists", null, Locale.ENGLISH)
                 ));

--- a/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
+++ b/server/src/main/java/com/sju18/petmanagement/global/storage/FileService.java
@@ -25,7 +25,7 @@ import java.util.*;
 @Service
 public class FileService {
     private final MessageSource msgSrc = MessageConfig.getStorageMessageSource();
-    private final String storageRootPath = "D:\\TempDev\\Pet-Management\\storage";
+    private final String storageRootPath = "C:\\Users\\fchop\\Development\\tmp\\Pet-Management\\storage";
     private final Integer MEDIA_FILE = 1;
     private final Integer GENERAL_FILE = 2;
 


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
커뮤니티(Post)에서 유저의 정보를 터치할 시, 해당 펫에 대한 PetProfileFragment를 실행합니다.

## 변경사항
 - post fragment에서 보여주는 사진은 account의 것인데, id는 pet_photo인 것을 확인하여, 오타를 수정하였습니다.
 - PostFragment에 fetchPetPhotoAndStartPetProfileFragment(), startPetProfileFragment() 함수를 추가하여 pet profile에 대한 linking을 구현하였습니다. PostListAdapter에서 interface를 통해 fetchPetPhotoAndStartPetProfileFragment()를 전달받으며, layout_user_info를 클릭하여 이 함수를 호출시킵니다.
 - [서버] 기존에 fetchPetPhoto()를 수행할 때, findByOwnernameAndId()로 펫을 검색하였는데, 이것을 findById()로 변경하였습니다. 만약 기존의 방식을 유지한 채로, 다른 계정의 펫 프로필로 이동하려고 하면, owner가 다르기 때문에 fetchPetPhoto 작업이 실패하여 함수가 작동하지 않습니다.
 
## 비고
 - 게시글에서 유저의 프로필을 열람하는 경우에는 주요 관심사는 Post에 묶여있는 Pet입니다. 따라서 이곳에서 대표펫은 고려하지 않으며, 대신 댓글에서 redirect할 때 대표펫으로 이동하는 것이 적합하다고 생각합니다.


https://user-images.githubusercontent.com/58168528/135279351-8599d7f0-fbb6-478d-98dd-395c4ee6887b.mp4




## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
