### PR TITLE
[hotfix/TransactionTooLargeException-fix] 안드로이드 Client TransactionTooLargeException 관련 버그 수정

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/MainActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/MainActivity.kt
@@ -209,6 +209,7 @@ class MainActivity : AppCompatActivity() {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putInt("active_fragment_index", activeFragmentIndex)
+        outState.clear()
     }
 
     // for action bar menu

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
@@ -36,10 +36,6 @@ import com.sju18001.petmanagement.ui.community.CommunityViewModel
 import com.sju18001.petmanagement.ui.community.comment.CommunityCommentActivity
 import com.sju18001.petmanagement.ui.community.post.createUpdatePost.CreateUpdatePostActivity
 import com.sju18001.petmanagement.ui.myPet.MyPetActivity
-import okhttp3.ResponseBody
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
 import java.io.File
 import java.io.FileOutputStream
 import java.time.LocalDate
@@ -493,7 +489,12 @@ class PostFragment : Fragment() {
         // set pet values to Intent
         val petProfileIntent = Intent(holder.itemView.context, MyPetActivity::class.java)
         if(photoByteArray != null) {
-            petProfileIntent.putExtra("photoByteArray", photoByteArray)
+            Util.saveByteArrayToSharedPreferences(requireContext(), requireContext().getString(R.string.pref_name_byte_arrays),
+                requireContext().getString(R.string.data_name_community_selected_pet_photo), photoByteArray)
+        }
+        else {
+            Util.saveByteArrayToSharedPreferences(requireContext(), requireContext().getString(R.string.pref_name_byte_arrays),
+                requireContext().getString(R.string.data_name_community_selected_pet_photo), null)
         }
         petProfileIntent.putExtra("petId", pet.id)
         petProfileIntent.putExtra("petName", pet.name)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageActivity.kt
@@ -84,6 +84,11 @@ class MyPageActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.clear()
+    }
+
     override fun finish() {
         super.finish()
         overridePendingTransition(R.anim.enter_from_left, R.anim.exit_to_right)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -17,10 +17,6 @@ import com.sju18001.petmanagement.restapi.ServerUtil
 import com.sju18001.petmanagement.restapi.SessionManager
 import com.sju18001.petmanagement.restapi.dao.Account
 import com.sju18001.petmanagement.restapi.dto.FetchAccountPhotoReqDto
-import okhttp3.ResponseBody
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
 import java.io.File
 
 class MyPageFragment : Fragment() {
@@ -65,7 +61,12 @@ class MyPageFragment : Fragment() {
             accountLookupIntent.putExtra("representativePetId", accountData.representativePetId)
 
             if(accountData.photoUrl != null) {
-                accountLookupIntent.putExtra("photoByteArray", myPageViewModel.accountPhotoProfileByteArray)
+                Util.saveByteArrayToSharedPreferences(requireContext(), requireContext().getString(R.string.pref_name_byte_arrays),
+                    requireContext().getString(R.string.data_name_my_page_selected_account_photo), myPageViewModel.accountPhotoProfileByteArray)
+            }
+            else {
+                Util.saveByteArrayToSharedPreferences(requireContext(), requireContext().getString(R.string.pref_name_byte_arrays),
+                    requireContext().getString(R.string.data_name_my_page_selected_account_photo), null)
             }
 
             startActivity(accountLookupIntent)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -417,7 +417,9 @@ class EditAccountFragment : Fragment() {
         myPageViewModel.accountMarketingValue = requireActivity().intent.getBooleanExtra("marketing", false)
         myPageViewModel.accountNicknameValue = requireActivity().intent.getStringExtra("nickname").toString()
         myPageViewModel.accountUserMessageValue = requireActivity().intent.getStringExtra("userMessage").toString()
-        myPageViewModel.accountPhotoByteArray = requireActivity().intent.getByteArrayExtra("photoByteArray")
+        myPageViewModel.accountPhotoByteArray = Util.getByteArrayFromSharedPreferences(requireContext(),
+            requireContext().getString(R.string.pref_name_byte_arrays),
+            requireContext().getString(R.string.data_name_my_page_selected_account_photo))
         myPageViewModel.representativePetId = requireActivity().intent.getLongExtra("representativePetId", 0)
     }
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -193,9 +193,16 @@ class PetProfileFragment : Fragment(){
 
     private fun savePetDataForPetProfile() {
         myPetViewModel.loadedFromIntent = true
-        myPetViewModel.petPhotoByteArrayProfile = Util.getByteArrayFromSharedPreferences(requireContext(),
-            requireContext().getString(R.string.pref_name_byte_arrays),
-            requireContext().getString(R.string.data_name_my_pet_selected_pet_photo))
+        if (requireActivity().intent.getStringExtra("fragmentType") == "pet_profile_pet_manager") {
+            myPetViewModel.petPhotoByteArrayProfile = Util.getByteArrayFromSharedPreferences(requireContext(),
+                requireContext().getString(R.string.pref_name_byte_arrays),
+                requireContext().getString(R.string.data_name_my_pet_selected_pet_photo))
+        }
+        else {
+            myPetViewModel.petPhotoByteArrayProfile = Util.getByteArrayFromSharedPreferences(requireContext(),
+                requireContext().getString(R.string.pref_name_byte_arrays),
+                requireContext().getString(R.string.data_name_community_selected_pet_photo))
+        }
         myPetViewModel.petNameValueProfile = requireActivity().intent.getStringExtra("petName").toString()
         myPetViewModel.petBirthValueProfile = requireActivity().intent.getStringExtra("petBirth").toString()
         myPetViewModel.petSpeciesValueProfile = requireActivity().intent.getStringExtra("petSpecies").toString()

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="data_name_pet_list_id_order">pet_list_id_order</string>
     <string name="pref_name_byte_arrays">ByteArrays</string>
     <string name="data_name_my_pet_selected_pet_photo">my_pet_selected_pet_photo</string>
+    <string name="data_name_community_selected_pet_photo">community_selected_pet_photo</string>
 
     <string name="fail_request">요청에 실패하였습니다.</string>
     <string name="try_again">잠시후 다시 시도해주세요.</string>

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="pref_name_byte_arrays">ByteArrays</string>
     <string name="data_name_my_pet_selected_pet_photo">my_pet_selected_pet_photo</string>
     <string name="data_name_community_selected_pet_photo">community_selected_pet_photo</string>
+    <string name="data_name_my_page_selected_account_photo">my_page_selected_account_photo</string>
 
     <string name="fail_request">요청에 실패하였습니다.</string>
     <string name="try_again">잠시후 다시 시도해주세요.</string>


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [X] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
안드로이드 Client의 TransactionTooLargeException 관련 버그를 수정하였습니다.
(해결 방법은 PR #125 와 동일하니, 더 자세한 내용은 해당 PR 확인 바랍니다.)

## 변경사항
- Intent 관련 버그 (사진의 byte array를 SharedPreferences에 저장하는 방법으로 해결)
    - 커뮤니티 탭에서 펫을 클릭하여 해당 펫 프로필 화면으로 이동하는 과정에서 crash 되던 버그 수정
    - 내 정보 탭에서 내 계정 정보 카드를 클릭하여 계정 정보 수정 화면으로 이동하는 과정에서 crash 되던 버그 수정
- 메모리 초과 관련 버그 (액티비티의 기존 state를 clear 하는 방법으로 해결)
    - 마이펫 탭에서 크기가 큰 사진을 가지는 펫이 여러 개 있을 때, 펫을 클릭하여 펫 프로필 화면으로 이동하는 과정에서 crash 되던 버그 수정 (새로 발견된 버그)
    - 내 정보 탭에서 계정 프로필 사진이 이미 존재하는 상태에서 사진을 변경하려고 할 시 crash 되던 버그 수정
 
## 비고
테스트 환경
- API 30과 API 26에서 테스트 완료

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [X] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [X] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [X] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [X] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [X] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [X] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
