### PR TITLE
[isViewDestroyed-fix] enqueueApiCall의 isViewDestroyed 문제 해결

### DIFF
--- a/client/android/.idea/misc.xml
+++ b/client/android/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/client/android/.idea/runConfigurations.xml
+++ b/client/android/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/MainActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/MainActivity.kt
@@ -276,7 +276,7 @@ class MainActivity : AppCompatActivity() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(baseContext)!!)
             .fetchPetScheduleReq(ServerUtil.getEmptyBody())
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, this, { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, this, { response ->
             // ON인 것들에 대해 알림 설정
             response.body()?.petScheduleList?.map{
                 if(it.enabled){

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/RetrofitBuilder.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/RetrofitBuilder.kt
@@ -31,8 +31,8 @@ class RetrofitBuilder {
                 .build()
 
             val retrofit = Retrofit.Builder()
-                //.baseUrl("http://220.85.251.6:9000/")
-                .baseUrl("http://10.0.2.2:8080/")
+                .baseUrl("http://220.85.251.6:9000/")
+                //.baseUrl("http://10.0.2.2:8080/")
                 .client(client)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
@@ -51,8 +51,8 @@ class RetrofitBuilder {
                 .build()
 
             val retrofit = Retrofit.Builder()
-                //.baseUrl("http://220.85.251.6:9000/")
-                .baseUrl("http://10.0.2.2:8080/")
+                .baseUrl("http://220.85.251.6:9000/")
+                //.baseUrl("http://10.0.2.2:8080/")
                 .client(client)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerUtil.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/restapi/ServerUtil.kt
@@ -19,7 +19,7 @@ class ServerUtil {
     companion object{
         fun <T> enqueueApiCall(
             call: Call<T>,
-            isViewDestroyed: Boolean,
+            getIsViewDestroyed: ()-> Boolean,
             context: Context,
             onSuccessful: (Response<T>)->Unit,
             onNotSuccessful: (Response<T>)->Unit,
@@ -27,7 +27,7 @@ class ServerUtil {
         ){
             call.enqueue(object: Callback<T> {
                 override fun onResponse(call: Call<T>, response: Response<T>) {
-                    if(isViewDestroyed) return
+                    if(getIsViewDestroyed()) return
 
                     if(response.isSuccessful){
                         onSuccessful.invoke(response)
@@ -38,7 +38,7 @@ class ServerUtil {
                 }
 
                 override fun onFailure(call: Call<T>, t: Throwable) {
-                    if(isViewDestroyed) return
+                    if(getIsViewDestroyed()) return
 
                     onFailure.invoke()
                     Util.showToastAndLog(context, t.message.toString())

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityUtil.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/CommunityUtil.kt
@@ -59,7 +59,7 @@ class CommunityUtil {
             // get the representative pet of account
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
                 .fetchPetReq(FetchPetReqDto(null, account.username))
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, context, { response ->
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, context, { response ->
                 if (response.body()?.petList!!.isEmpty()) {
                     val emptyPetListMessage = account.nickname + context.getText(R.string.empty_pet_list_for_account_message)
                     Toast.makeText(context, emptyPetListMessage, Toast.LENGTH_LONG).show()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/CommunityCommentFragment.kt
@@ -139,7 +139,7 @@ class CommunityCommentFragment : Fragment() {
             override fun fetchReplyComment(pageIndex: Int, topReplyId: Long?, parentCommentId: Long, position: Int){
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .fetchCommentReq(FetchCommentReqDto(pageIndex, topReplyId, null, parentCommentId, null))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                     response.body()?.let{
                         // Set topReplyId
                         if(topReplyId == null){
@@ -256,7 +256,7 @@ class CommunityCommentFragment : Fragment() {
     private fun deleteComment(id: Long, position: Int){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .deleteCommentReq(DeleteCommentReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             Toast.makeText(context, context?.getText(R.string.delete_comment_success), Toast.LENGTH_SHORT).show()
 
             adapter.removeItem(position)
@@ -274,7 +274,7 @@ class CommunityCommentFragment : Fragment() {
     private fun updateAdapterDataSetByFetchComment(body: FetchCommentReqDto){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchCommentReq(body)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             isLast = response.body()!!.isLast == true
 
             response.body()!!.commentList?.let {
@@ -353,11 +353,11 @@ class CommunityCommentFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .createCommentReq(body)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             // 생성된 댓글의 id로 FetchComment
             val callForFetchingComment = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .fetchCommentReq(FetchCommentReqDto(null, null, null, null, it.body()!!.id))
-            ServerUtil.enqueueApiCall(callForFetchingComment, isViewDestroyed, requireContext(), { it2 ->
+            ServerUtil.enqueueApiCall(callForFetchingComment, {isViewDestroyed}, requireContext(), { it2 ->
                 // RecyclerView에 추가
                 it2.body()!!.commentList?.get(0)?.let { item ->
                     // 생성된 댓글이 답글일 경우
@@ -416,7 +416,7 @@ class CommunityCommentFragment : Fragment() {
     private fun setAccountPhotoToImageView(id: Long, imageView: ImageView) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // convert photo to byte array + get bitmap
             val photoByteArray = response.body()!!.byteStream().readBytes()
             val photoBitmap = BitmapFactory.decodeByteArray(photoByteArray, 0, photoByteArray.size)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/comment/updateComment/UpdateCommentFragment.kt
@@ -86,7 +86,7 @@ class UpdateCommentFragment : Fragment() {
             requireActivity().intent.getLongExtra("id", -1), binding.editTextUpdateComment.text.toString()
         )
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!).updateCommentReq(body)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             // Pass datum for comment
             val intent = Intent()
             val newContents = binding.editTextUpdateComment.text.toString().replace("\n", "")

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerAdapter.kt
@@ -94,7 +94,7 @@ class FollowerAdapter(val context: Context) :
     private fun createFollow(id: Long, holder: HistoryListViewHolder, position: Int) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
             .createFollowReq(CreateFollowReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, context, {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, context, {
             // update isFollowing and button state
             val currentItem = resultList[position]
             currentItem.setValues(
@@ -112,7 +112,7 @@ class FollowerAdapter(val context: Context) :
     private fun deleteFollow(id: Long, holder: HistoryListViewHolder, position: Int) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
             .deleteFollowReq(DeleteFollowReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, context, {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, context, {
             // update isFollowing and button state
             val currentItem = resultList[position]
             currentItem.setValues(
@@ -132,7 +132,7 @@ class FollowerAdapter(val context: Context) :
     private fun setAccountPhoto(id: Long, holder: HistoryListViewHolder, position: Int) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, context, { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, context, { response ->
             // convert photo to byte array + get bitmap
             val photoByteArray = response.body()!!.byteStream().readBytes()
             val photoBitmap = BitmapFactory.decodeByteArray(photoByteArray, 0, photoByteArray.size)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFollowingFragment.kt
@@ -131,7 +131,7 @@ class FollowerFollowingFragment : Fragment() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchFollowingReq(ServerUtil.getEmptyBody())
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             val followerCount = response.body()!!.followingList.size
 
             // set follower count
@@ -145,7 +145,7 @@ class FollowerFollowingFragment : Fragment() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchFollowerReq(ServerUtil.getEmptyBody())
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             val followingCount = response.body()!!.followerList.size
 
             // set following count

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowerFragment.kt
@@ -95,7 +95,7 @@ class FollowerFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchFollowerReq(ServerUtil.getEmptyBody())
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             response.body()!!.followerList.map {
                 followingIdList.add(it.id)
             }
@@ -110,7 +110,7 @@ class FollowerFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchFollowingReq(ServerUtil.getEmptyBody())
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             response.body()!!.followingList.map {
                 val hasPhoto = it.photoUrl != null
                 val id = it.id

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingAdapter.kt
@@ -100,7 +100,7 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
             .deleteFollowReq(DeleteFollowReqDto(id))
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, context, {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, context, {
             holder.followUnfollowButton.isEnabled = true
 
             // remove from list
@@ -125,7 +125,7 @@ class FollowingAdapter(val context: Context, val followerFollowingViewModel: Fol
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, context, { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, context, { response ->
             // convert photo to byte array + get bitmap
             val photoByteArray = response.body()!!.byteStream().readBytes()
             val photoBitmap = BitmapFactory.decodeByteArray(photoByteArray, 0, photoByteArray.size)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/FollowingFragment.kt
@@ -95,7 +95,7 @@ class FollowingFragment : Fragment() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchFollowerReq(ServerUtil.getEmptyBody())
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             response.body()!!.followerList.map {
                 val hasPhoto = it.photoUrl != null
                 val id = it.id

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/followerFollowing/SearchActivity.kt
@@ -195,7 +195,7 @@ class SearchActivity : AppCompatActivity() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(baseContext)!!)
             .fetchFollowerReq(ServerUtil.getEmptyBody())
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, this@SearchActivity, { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, this@SearchActivity, { response ->
             response.body()!!.followerList.map {
                 searchViewModel.followerIdList!!.add(it.id)
             }
@@ -208,7 +208,7 @@ class SearchActivity : AppCompatActivity() {
     private fun searchAccount(nickname: String) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(baseContext)!!)
             .fetchAccountByNicknameReq(FetchAccountReqDto(null, null, nickname))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, this@SearchActivity, { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, this@SearchActivity, { response ->
             // set api state/button to normal
             searchViewModel.apiIsLoading = false
             unlockViews()
@@ -244,7 +244,7 @@ class SearchActivity : AppCompatActivity() {
     private fun fetchAccountPhoto(id: Long) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(baseContext)!!)
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, this@SearchActivity, { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, this@SearchActivity, { response ->
             // save photo as byte array
             searchViewModel.accountPhotoByteArray = response.body()!!.byteStream().readBytes()
 
@@ -256,7 +256,7 @@ class SearchActivity : AppCompatActivity() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(baseContext)!!)
             .createFollowReq(CreateFollowReqDto(searchViewModel.accountId!!))
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, this@SearchActivity, {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, this@SearchActivity, {
             updateFollowerIdList()
 
             searchViewModel.apiIsLoading = false
@@ -271,7 +271,7 @@ class SearchActivity : AppCompatActivity() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(baseContext)!!)
             .deleteFollowReq(DeleteFollowReqDto(searchViewModel.accountId!!))
 
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, this@SearchActivity, {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, this@SearchActivity, {
             updateFollowerIdList()
 
             searchViewModel.apiIsLoading = false

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/PostFragment.kt
@@ -104,7 +104,7 @@ class PostFragment : Fragment() {
     private fun fetchOnePostAndInvoke(postId: Long, callback: ((Post)->Unit)){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPostReq(FetchPostReqDto(null, null, null, postId))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             response.body()?.postList?.get(0)?.let{ item ->
                 // 펫이 지정되어있지만 pet id가 다를 경우에는 invoke 하지 않음
                 val petId = arguments?.getLong("petId")
@@ -165,7 +165,7 @@ class PostFragment : Fragment() {
             override fun createLike(postId: Long, holder: PostListAdapter.ViewHolder, position: Int){
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .createLikeReq(CreateLikeReqDto(postId, null))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
                     holder.likeCountTextView.text = ((holder.likeCountTextView.text).toString().toLong() + 1).toString()
 
                     adapter.setIsPostLiked(position, true)
@@ -179,7 +179,7 @@ class PostFragment : Fragment() {
             override fun deleteLike(postId: Long, holder: PostListAdapter.ViewHolder, position: Int) {
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .deleteLikeReq(DeleteLikeReqDto(postId, null))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
                     holder.likeCountTextView.text = ((holder.likeCountTextView.text).toString().toLong() - 1).toString()
 
                     adapter.setIsPostLiked(position, false)
@@ -203,7 +203,7 @@ class PostFragment : Fragment() {
             override fun setAccountPhoto(id: Long, holder: PostListAdapter.ViewHolder){
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .fetchAccountPhotoReq(FetchAccountPhotoReqDto(id))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                     // convert photo to byte array + get bitmap
                     val photoByteArray = response.body()!!.byteStream().readBytes()
                     val photoBitmap = BitmapFactory.decodeByteArray(photoByteArray, 0, photoByteArray.size)
@@ -225,7 +225,7 @@ class PostFragment : Fragment() {
             ) {
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .fetchPostMediaReq(FetchPostMediaReqDto(id, index))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                     if(Util.isUrlVideo(url)){
                         // Save file
                         val dir = File(requireContext().getExternalFilesDir(null).toString() +
@@ -352,7 +352,7 @@ class PostFragment : Fragment() {
     private fun updateAdapterDataSet(body: FetchPostReqDto){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPostReq(body)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             isLast = response.body()!!.isLast == true
 
             response.body()!!.postList?.let {
@@ -384,7 +384,7 @@ class PostFragment : Fragment() {
     private fun setLiked(position: Int, postId: Long){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchLikeReq(FetchLikeReqDto(postId, null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             adapter.setLikedCount(position, response.body()!!.likedCount!!)
 
             val flag = response.body()!!.likedAccountIdList?.contains(SessionManager.fetchLoggedInAccount(requireContext())!!.id)?: false
@@ -443,7 +443,7 @@ class PostFragment : Fragment() {
     private fun deletePost(id: Long, position: Int){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .deletePostReq(DeletePostReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             // 데이터셋에서 삭제
             adapter.removeItem(position)
             adapter.notifyItemRemoved(position)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/createUpdatePost/CreateUpdatePostFragment.kt
@@ -336,7 +336,7 @@ class CreateUpdatePostFragment : Fragment() {
     private fun setPetSpinnerAndPhoto() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPetReq(FetchPetReqDto( null , null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // get pet id and name
             val apiResponse: MutableList<Pet> = mutableListOf()
             response.body()?.petList?.map {
@@ -596,7 +596,7 @@ class CreateUpdatePostFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .createPostReq(createPostReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // Pass post id to Community
             val intent = Intent()
             intent.putExtra("postId", response.body()!!.id)
@@ -644,7 +644,7 @@ class CreateUpdatePostFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updatePostReq(updatePostReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             // no media files
             if(createUpdatePostViewModel.photoVideoPathList.size == 0) {
                 // 기존에 Media가 0개였다면 DeletePostMedia를 호출하지 않는다.
@@ -670,7 +670,7 @@ class CreateUpdatePostFragment : Fragment() {
     private fun deletePostMedia(id: Long) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .deletePostMediaReq(DeletePostMediaReqDto(id))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             passDataToCommunity()
             closeAfterSuccess()
         }, {
@@ -701,7 +701,7 @@ class CreateUpdatePostFragment : Fragment() {
             // API call
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .updatePostMediaReq(id, fileList)
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
                 passDataToCommunity()
                 closeAfterSuccess()
             }, {
@@ -719,7 +719,7 @@ class CreateUpdatePostFragment : Fragment() {
     private fun getIdAndUpdateMedia() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPostReq(FetchPostReqDto(0, null, createUpdatePostViewModel.petId, null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             val postId = (response.body()?.postList?.get(0) as Post).id
             updatePostMedia(postId)
         }, {
@@ -736,7 +736,7 @@ class CreateUpdatePostFragment : Fragment() {
         for(index in postMedia.indices) {
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .fetchPostMediaReq(FetchPostMediaReqDto(createUpdatePostViewModel.postId!!, index))
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                 // get file extension
                 val extension = postMedia[index].name.split('.').last()
 
@@ -779,7 +779,7 @@ class CreateUpdatePostFragment : Fragment() {
     private fun fetchPostData() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPostReq(FetchPostReqDto(null, null, null, createUpdatePostViewModel.postId))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // fetch post data(excluding media) and save to ViewModel
             val post = response.body()?.postList!![0]
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/LoginFragment.kt
@@ -189,7 +189,7 @@ class LoginFragment : Fragment() {
                             // nickname => username 변경
                             val call = RetrofitBuilder.getServerApiWithToken(token)
                                 .updateAccountReq(UpdateAccountReqDto(it.email, it.phone, it.username, it.marketing, it.userMessage, it.representativePetId))
-                            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {}, {}, {})
+                            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {}, {}, {})
 
                             // 웰컴 페이지 호출
                             val intent = Intent(context, WelcomePageActivity::class.java)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverPasswordFragment.kt
@@ -178,7 +178,7 @@ class RecoverPasswordFragment : Fragment() {
         lockViews()
 
         val call = RetrofitBuilder.getServerApi().sendAuthCodeReq(SendAuthCodeReqDto(email))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             // 버튼 로딩 상태 해제
             setEmailInputButtonLoading(false)
             unlockViews()
@@ -216,7 +216,7 @@ class RecoverPasswordFragment : Fragment() {
         lockViews()
 
         val call = RetrofitBuilder.getServerApi().recoverPasswordReq(RecoverPasswordReqDto(username, code))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             setCodeInputButtonLoading(false)
             unlockViews()
 

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/login/recovery/RecoverUsernameFragment.kt
@@ -135,7 +135,7 @@ class RecoverUsernameFragment : Fragment() {
         lockViews()
 
         val call = RetrofitBuilder.getServerApi().recoverUsernameReq(RecoverUsernameReqDto(email))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // 버튼 로딩 상태 해제
             setButtonLoading(false)
             unlockViews()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/map/MapFragment.kt
@@ -268,7 +268,7 @@ class MapFragment : Fragment(), MapView.CurrentLocationEventListener, MapView.Ma
                 currentMapPoint!!.mapPointGeoCoord.latitude.toString(),
                 searchRadiusMeter
             )
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                 val body = response.body()
                 if(body != null){
                     currentDocuments = body.documents

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/MyPageFragment.kt
@@ -160,7 +160,7 @@ class MyPageFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // save in ViewModel by byte array
             myPageViewModel.accountPhotoProfileByteArray = response.body()!!.byteStream().readBytes()
             binding.accountPhoto.setImageBitmap(BitmapFactory.decodeByteArray(myPageViewModel.accountPhotoProfileByteArray, 0, myPageViewModel.accountPhotoProfileByteArray!!.size))

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPage/account/EditAccountFragment.kt
@@ -296,7 +296,7 @@ class EditAccountFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updateAccountReq(updateAccountReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             if(response.body()?._metadata?.status == true) {
                 updateAccountPhoto(myPageViewModel.accountPhotoPathValue)
 
@@ -358,7 +358,7 @@ class EditAccountFragment : Fragment() {
             val updateAccountPhotoReq = MultipartBody.Part.createFormData("file", File(path).name, RequestBody.create(MediaType.parse("multipart/form-data"), File(path)))
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .updateAccountPhotoReq(updateAccountPhotoReq)
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                 // 세션 갱신
                 val account = SessionManager.fetchLoggedInAccount(requireContext())!!
                 account.photoUrl = response.body()!!.fileUrl
@@ -374,7 +374,7 @@ class EditAccountFragment : Fragment() {
     private fun updateAccountPassword(newPassword: String, password: String) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updateAccountPasswordReq(UpdateAccountPasswordReqDto(password, newPassword))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             if(response.body()?._metadata?.status == true) {
                 Toast.makeText(context, context?.getText(R.string.account_password_changed), Toast.LENGTH_LONG).show()
             }
@@ -402,7 +402,7 @@ class EditAccountFragment : Fragment() {
     private fun deleteAccount() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .deleteAccountReq(ServerUtil.getEmptyBody())
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             if(response.body()?._metadata?.status == true) {
                 Toast.makeText(context, context?.getText(R.string.account_delete_success), Toast.LENGTH_LONG).show()
                 logout()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/CreateUpdatePetFragment.kt
@@ -240,7 +240,7 @@ class CreateUpdatePetFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .createPetReq(createPetRequestDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             getIdAndUpdatePhoto()
         }, { response ->
             // set api state/button to normal
@@ -286,7 +286,7 @@ class CreateUpdatePetFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updatePetReq(updatePetReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             updatePetPhoto(myPetViewModel.petIdValue!!, myPetViewModel.petPhotoPathValue)
         }, {
             // set api state/button to normal
@@ -356,7 +356,7 @@ class CreateUpdatePetFragment : Fragment() {
             val file = MultipartBody.Part.createFormData("file", File(path).name, RequestBody.create(MediaType.parse("multipart/form-data"), File(path)))
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .updatePetPhotoReq(id, file)
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
                 File(path).delete()
 
                 closeAfterSuccess()
@@ -375,7 +375,7 @@ class CreateUpdatePetFragment : Fragment() {
     private fun getIdAndUpdatePhoto() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPetReq(FetchPetReqDto( null , null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             val petIdList: ArrayList<Long> = ArrayList()
             response.body()?.petList?.map {
                 petIdList.add(it.id)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetListAdapter.kt
@@ -160,7 +160,7 @@ class PetListAdapter(private val startDragListener: OnStartDragListener, private
     private fun fetchPetPhoto(id: Long, view: View) {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(context)!!)
             .fetchPetPhotoReq(FetchPetPhotoReqDto(id))
-        ServerUtil.enqueueApiCall(call, false, context, { response ->
+        ServerUtil.enqueueApiCall(call, {false}, context, { response ->
             // set fetched photo to view
             (view as ImageView).setImageBitmap(BitmapFactory.decodeStream(response.body()!!.byteStream()))
         }, {}, {})

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetManagerFragment.kt
@@ -93,7 +93,7 @@ class PetManagerFragment : Fragment(), OnStartDragListener {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPetReq(FetchPetReqDto( null , null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             val petListApi: ArrayList<Pet> = ArrayList()
             response.body()?.petList?.map {
                 petListApi.add(it)

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petManager/PetProfileFragment.kt
@@ -219,7 +219,7 @@ class PetProfileFragment : Fragment(){
         else {
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .fetchPetPhotoReq(FetchPetPhotoReqDto(myPetViewModel.petIdValueProfile!!))
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                 myPetViewModel.petPhotoByteArrayProfile = response.body()!!.bytes()
                 setPhotoViews()
             }, {}, {})
@@ -280,7 +280,7 @@ class PetProfileFragment : Fragment(){
     private fun setPetSpinner() {
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPetReq(FetchPetReqDto(null, myPetViewModel.accountUsernameValue))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // get pet id and name
             val apiResponse: MutableList<Pet> = mutableListOf()
             response.body()?.petList?.map {
@@ -338,7 +338,7 @@ class PetProfileFragment : Fragment(){
         else {
             val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                 .fetchAccountPhotoReq(FetchAccountPhotoReqDto(myPetViewModel.accountIdValue))
-            ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+            ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                 myPetViewModel.accountPhotoByteArray = response.body()!!.bytes()
                 setPhotoViews()
             }, {}, {})
@@ -365,7 +365,7 @@ class PetProfileFragment : Fragment(){
             else {
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .fetchPetPhotoReq(FetchPetPhotoReqDto(requireActivity().intent.getLongExtra("petId", -1)))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                     myPetViewModel.petPhotoByteArrayProfile = response.body()!!.bytes()
                     setPhotoViews()
                 }, {}, {})
@@ -463,7 +463,7 @@ class PetProfileFragment : Fragment(){
         // update account
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updateAccountReq(updateAccountReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             if (response.body()?._metadata?.status == true) {
                 // update session(update representative pet id value)
                 val account = Account(
@@ -499,7 +499,7 @@ class PetProfileFragment : Fragment(){
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .deletePetReq(DeletePetReqDto(requireActivity().intent.getLongExtra("petId", -1)))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             // set api state/button to normal
             myPetViewModel.petManagerApiIsLoading = false
             enableButton()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleEditFragment.kt
@@ -154,7 +154,7 @@ class PetScheduleEditFragment : Fragment() {
     private fun addPetNameList(){
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPetReq(FetchPetReqDto( null , null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             response.body()?.petList?.map {
                 adapter.addItem(PetNameListItem(it.name, it.id))
             }
@@ -181,7 +181,7 @@ class PetScheduleEditFragment : Fragment() {
         )
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .createPetScheduleReq(createPetScheduleReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             activity?.finish()
         }, {
             unlockViews()
@@ -199,7 +199,7 @@ class PetScheduleEditFragment : Fragment() {
         )
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .updatePetScheduleReq(updatePetScheduleReqDto)
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {
             activity?.finish()
         }, {
             unlockViews()

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/myPet/petScheduleManager/PetScheduleManagerFragment.kt
@@ -123,7 +123,7 @@ class PetScheduleManagerFragment : Fragment() {
             override fun deletePetSchedule(id: Long) {
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .deletePetScheduleReq(DeletePetScheduleReqDto(id))
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {}, {}, {})
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {}, {}, {})
             }
 
             @RequiresApi(Build.VERSION_CODES.O)
@@ -133,7 +133,7 @@ class PetScheduleManagerFragment : Fragment() {
                 )
                 val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
                     .updatePetScheduleReq(updatePetScheduleReqDto)
-                ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {}, {}, {})
+                ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {}, {}, {})
             }
 
             override fun getContext(): Context {
@@ -165,7 +165,7 @@ class PetScheduleManagerFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchPetScheduleReq(ServerUtil.getEmptyBody())
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             // dataSet에 값 저장
             response.body()?.petScheduleList?.map{
                 dataSet.add(PetSchedule(

--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/welcomePage/WelcomePageProfileFragment.kt
@@ -94,7 +94,7 @@ class WelcomePageProfileFragment : Fragment() {
 
         val call = RetrofitBuilder.getServerApiWithToken(SessionManager.fetchUserToken(requireContext())!!)
             .fetchAccountPhotoReq(FetchAccountPhotoReqDto(null))
-        ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), { response ->
+        ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
             accountLookupIntent.putExtra("photoByteArray", response.body()!!.byteStream().readBytes())
 
             startActivity(accountLookupIntent)


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [x] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
![image](https://user-images.githubusercontent.com/58168528/141119676-88ddb71b-8878-4028-91df-b032245cd36a.png)
위 상황을 고려하겠습니다. 기존의 방식에서 댓글을 삭제한다고 할 때, isViewDestroyed에 false 값이 전달되었을 것입니다. 하지만 API 호출이 끝나기 전에 뷰가 제거되어 댓글 프래그먼트의 isViewDestroyed가 true가 되었습니다. 하지만 문제는, enqueueApiCall()에서는 이 '최신의 값'인 true를 반영하지 않는다는 것입니다. 왜냐하면 이미 전달된 파라미터 isViewDestroyed(false)가, 함수 외부에서 영향을 받을 리가 없기 때문입니다.
따라서 파라미터인 isViewDestroyed: Boolean을 getIsViewDestroyed: ()->Boolean으로 변경하였습니다.

## 변경사항
 - enqueueApiCall() 함수의 isViewDestroyed를 람다함수인 getIsViewDestroyed로 변경하였습니다.
 - 이에 따라 프로젝트 내 모든 enqueueApiCall()에 대해 수정을 하였습니다.
 
## 비고
 - 해당 함수의 사용이 조금 달라졌습니다. 하지만 기존의 것과 거의 유사한데, ServerUtil.enqueueApiCall(call, isViewDestroyed, requireContext(), {}, {}, {})의 형태에서 ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), {}, {}, {})로 바뀌었습니다.(**isViewDestroyed -> {isViewDestroyed}**)

 - 다음은 테스트 방법입니다.
![image](https://user-images.githubusercontent.com/58168528/141121527-56617c97-73f2-44b8-8fd5-898ec90d083a.png)
위와 같이 호출을 하자마자 isViewDestroyed를 true로 변경합니다. 다시 말해서, 위 다이어그램처럼 댓글 삭제를 요청하자마자 뷰가 죽은 상황을 가정한 코드입니다. 만약 댓글이 삭제된다면 제대로 되지 않은 코드일 것이며, 반대로 삭제가 되지 않는다면 정상적인 작동입니다.

기존의 코드에서 테스트한 결과는 다음과 같습니다.

https://user-images.githubusercontent.com/58168528/141121766-52f5765b-9caf-460c-a051-a4f8212c8340.mp4

다음은 해당 PR 이후의 테스트 결과입니다.

https://user-images.githubusercontent.com/58168528/141121827-27429a3c-4984-4a50-bbbe-217f540a2816.mp4

뷰가 제거되었기 때문에 이후의 작업을 하지 않았으므로, 정상적으로 작동한 것입니다.

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
