### PR TITLE
[Hotfix/fetchPostMediaData-fix] 글 수정할 때의 fetchPostMediaData 버그 수정

### DIFF
--- a/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/createUpdatePost/CreateUpdatePostFragment.kt
+++ b/client/android/app/src/main/java/com/sju18001/petmanagement/ui/community/post/createUpdatePost/CreateUpdatePostFragment.kt
@@ -738,7 +738,7 @@ class CreateUpdatePostFragment : Fragment() {
                 .fetchPostMediaReq(FetchPostMediaReqDto(createUpdatePostViewModel.postId!!, index))
             ServerUtil.enqueueApiCall(call, {isViewDestroyed}, requireContext(), { response ->
                 // get file extension
-                val extension = postMedia[index].name.split('.').last()
+                val extension = postMedia[index].url.split('.').last()
 
                 // copy file and get real path
                 val mediaByteArray = response.body()!!.byteStream().readBytes()


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [x] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용

https://user-images.githubusercontent.com/58168528/141468709-3b355c4c-33ed-4d18-ab07-d7b1cad6df4b.mp4

이미 사진이 있는 글을 수정하는 페이지로 진입할 때, fetchPostMediaData()를 통해 글의 사진들을 불러옵니다. 이 때, mediaAttachment의 name에서 suffix를 따와서 파일의 확장자명을 가져왔으나, **어째서인지**(이에 대해 원인을 아시는 분은 언급해주시면 감사하겠습니다.) name에 확장자명이 없어서("post_19_file_0\" 같은 형식으로 저장되어있음) 확장자명을 가져올 수 없는 문제가 발생하였습니다. 따라서 확장자명이 여전히 담겨져있는 url("\...\post_19_file_0.jpg\"와 같은 형식으로 저장되어 있음)에서 확장자명을 가져오는 방식으로 변경하였습니다.

## 변경사항
 - 확장자명을 가져올 때, postMedia의 name이 아니라, url로 접근하여 가져옵니다.
 
## 비고


## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
 - [ ] 자동화 단위 테스트 / Unit Test (JUnit 등을 통해 개별 단위로직에 대한 테스트 스크립트 작성)
 - [ ] 자동화 통합 테스트 / Integration Test (Spring MVC Testing 등을 통해 프로그램 전체에 대한 테스트 스크립트 작성)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
